### PR TITLE
Add `/feed/translate/{languageCode}` endpoints

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -14,3 +14,7 @@ DATABASE_PASSWORD=""
 SWAGGER_TITLE="Wiki Feats API"
 SWAGGER_DESCRIPTION="API Documentation"
 SWAGGER_VERSION="1.0.0"
+
+# - External APIs - #
+
+LIBRE_TRANSLATE_API_URL="http://localhost:5000"

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,12 +3,14 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { mikroOrmConfig } from "./config/mikro-orm.config";
 import { FeedModule } from "./modules/feed/feed.module";
+import { TranslateModule } from "./modules/translate/translate.module";
 
 @Module({
   imports: [
-    ConfigModule.forRoot(),
+    ConfigModule.forRoot({ isGlobal: true }),
     MikroOrmModule.forRoot(mikroOrmConfig),
     FeedModule,
+    TranslateModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/common/helpers/expect.utils.ts
+++ b/backend/src/common/helpers/expect.utils.ts
@@ -1,0 +1,11 @@
+export const expectCallsInMethods = (methods: (() => jest.Mock)[]) => {
+  methods.forEach((method) => {
+    expect(method).toHaveBeenCalled();
+  });
+};
+
+export const expectNoCallsInMethods = (methods: (() => jest.Mock)[]) => {
+  methods.forEach((method) => {
+    expect(method).not.toHaveBeenCalled();
+  });
+};

--- a/backend/src/database/entities/article-collection.entity.ts
+++ b/backend/src/database/entities/article-collection.entity.ts
@@ -17,7 +17,7 @@ export class ArticleCollection extends BaseEntity {
   @ManyToOne({ entity: () => Language, joinColumn: "language_id", eager: true })
   language: Language;
 
-  @OneToMany(() => Article, (article) => article.collection, {
+  @OneToMany(() => Article, (article) => article.articleCollection, {
     orphanRemoval: true,
     eager: false,
   })

--- a/backend/src/database/entities/article-collection.entity.ts
+++ b/backend/src/database/entities/article-collection.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, ManyToOne, OneToMany, Property } from "@mikro-orm/core";
+import { BaseEntity } from "../../common/database/base.entity";
+import { Article } from "./article.entity";
+import { Language } from "./language.entity";
+
+@Entity({ tableName: "article_collections" })
+export class ArticleCollection extends BaseEntity {
+  @Property({ name: "featured_date", type: "date" })
+  featuredDate: Date;
+
+  @Property({ name: "available_articles", type: "integer" })
+  availableArticles: number;
+
+  @Property({ name: "total_articles", type: "integer" })
+  totalArticles: number;
+
+  @ManyToOne({ entity: () => Language, joinColumn: "language_id", eager: true })
+  language: Language;
+
+  @OneToMany(() => Article, (article) => article.collection, {
+    orphanRemoval: true,
+    eager: false,
+  })
+  articles: Article[];
+}

--- a/backend/src/database/entities/article.entity.ts
+++ b/backend/src/database/entities/article.entity.ts
@@ -15,8 +15,8 @@ export class Article extends BaseEntity {
   @Property({ name: "extract_html", type: "text" })
   extractHtml: string;
 
-  @Property({ type: "text" })
-  context: string;
+  @Property({ type: "text", nullable: true })
+  context?: string;
 
   @Property({ name: "article_url", type: "text" })
   articleUrl: string;
@@ -37,5 +37,5 @@ export class Article extends BaseEntity {
   thumbnail: Thumbnail;
 
   @ManyToOne({ entity: () => ArticleCollection, joinColumn: "collection_id" })
-  collection: ArticleCollection;
+  articleCollection: ArticleCollection;
 }

--- a/backend/src/database/entities/article.entity.ts
+++ b/backend/src/database/entities/article.entity.ts
@@ -12,6 +12,12 @@ export class Article extends BaseEntity {
   @Property({ type: "text" })
   extract: string;
 
+  @Property({ name: "extract_html", type: "text" })
+  extractHtml: string;
+
+  @Property({ type: "text" })
+  context: string;
+
   @Property({ name: "article_url", type: "text" })
   articleUrl: string;
 

--- a/backend/src/database/entities/article.entity.ts
+++ b/backend/src/database/entities/article.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, Enum, OneToOne, Property } from "@mikro-orm/core";
+import { Entity, Enum, ManyToOne, OneToOne, Property } from "@mikro-orm/core";
 import { ArticleType } from "../../common/@types/enum/article-type.enum";
 import { BaseEntity } from "../../common/database/base.entity";
+import { ArticleCollection } from "./article-collection.entity";
 import { Thumbnail } from "./thumbnail.entity";
 
 @Entity({ tableName: "articles" })
@@ -20,9 +21,6 @@ export class Article extends BaseEntity {
   @Property({ name: "wikipedia_page_id" })
   wikipediaPageId: number;
 
-  @Property({ name: "featured_date", type: "date" })
-  featuredDate: Date;
-
   @OneToOne({
     joinColumn: "thumbnail_id",
     owner: true,
@@ -31,4 +29,7 @@ export class Article extends BaseEntity {
     nullable: true,
   })
   thumbnail: Thumbnail;
+
+  @ManyToOne({ entity: () => ArticleCollection, joinColumn: "collection_id" })
+  collection: ArticleCollection;
 }

--- a/backend/src/database/entities/article.entity.ts
+++ b/backend/src/database/entities/article.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Enum, ManyToOne, OneToOne, Property } from "@mikro-orm/core";
+import { Entity, Enum, ManyToOne, Property } from "@mikro-orm/core";
 import { ArticleType } from "../../common/@types/enum/article-type.enum";
 import { BaseEntity } from "../../common/database/base.entity";
 import { ArticleCollection } from "./article-collection.entity";
@@ -27,10 +27,8 @@ export class Article extends BaseEntity {
   @Property({ name: "wikipedia_page_id" })
   wikipediaPageId: number;
 
-  @OneToOne({
+  @ManyToOne({
     joinColumn: "thumbnail_id",
-    owner: true,
-    orphanRemoval: true,
     eager: true,
     nullable: true,
   })

--- a/backend/src/database/entities/language.entity.ts
+++ b/backend/src/database/entities/language.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, OneToMany, Property } from "@mikro-orm/core";
+import { BaseEntity } from "../../common/database/base.entity";
+import { ArticleCollection } from "./article-collection.entity";
+
+@Entity({ tableName: "languages" })
+export class Language extends BaseEntity {
+  @Property()
+  name: string;
+
+  @Property()
+  code: string;
+
+  @OneToMany(
+    () => ArticleCollection,
+    (articleCollection) => articleCollection.language,
+    {
+      orphanRemoval: false,
+      eager: false,
+    },
+  )
+  articleCollections: ArticleCollection[];
+}

--- a/backend/src/database/entities/thumbnail.entity.ts
+++ b/backend/src/database/entities/thumbnail.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, Property } from "@mikro-orm/core";
+import { Entity, OneToMany, Property } from "@mikro-orm/core";
 import { BaseEntity } from "../../common/database/base.entity";
+import { Article } from "./article.entity";
 
 @Entity({ tableName: "thumbnails" })
 export class Thumbnail extends BaseEntity {
@@ -11,4 +12,10 @@ export class Thumbnail extends BaseEntity {
 
   @Property()
   height: number;
+
+  @OneToMany(() => Article, (article) => article.thumbnail, {
+    orphanRemoval: false,
+    eager: false,
+  })
+  articles: Article[];
 }

--- a/backend/src/database/migrations/.snapshot-wiki-feats-db.json
+++ b/backend/src/database/migrations/.snapshot-wiki-feats-db.json
@@ -352,7 +352,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "mappedType": "text"
         },
         "article_url": {

--- a/backend/src/database/migrations/.snapshot-wiki-feats-db.json
+++ b/backend/src/database/migrations/.snapshot-wiki-feats-db.json
@@ -337,6 +337,24 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "extract_html": {
+          "name": "extract_html",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "text"
+        },
         "article_url": {
           "name": "article_url",
           "type": "text",

--- a/backend/src/database/migrations/.snapshot-wiki-feats-db.json
+++ b/backend/src/database/migrations/.snapshot-wiki-feats-db.json
@@ -45,6 +45,193 @@
           "length": 6,
           "mappedType": "datetime"
         },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "string"
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "string"
+        }
+      },
+      "name": "languages",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "languages_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "featured_date": {
+          "name": "featured_date",
+          "type": "date",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "date"
+        },
+        "available_articles": {
+          "name": "available_articles",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "integer"
+        },
+        "total_articles": {
+          "name": "total_articles",
+          "type": "int",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "integer"
+        },
+        "language_id": {
+          "name": "language_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        }
+      },
+      "name": "article_collections",
+      "schema": "public",
+      "indexes": [
+        {
+          "keyName": "article_collections_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "article_collections_language_id_foreign": {
+          "constraintName": "article_collections_language_id_foreign",
+          "columnNames": [
+            "language_id"
+          ],
+          "localTableName": "public.article_collections",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.languages",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "mappedType": "uuid"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "length": 6,
+          "mappedType": "datetime"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "length": 6,
+          "mappedType": "datetime"
+        },
         "url": {
           "name": "url",
           "type": "text",
@@ -183,15 +370,6 @@
           "nullable": false,
           "mappedType": "integer"
         },
-        "featured_date": {
-          "name": "featured_date",
-          "type": "date",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "mappedType": "date"
-        },
         "thumbnail_id": {
           "name": "thumbnail_id",
           "type": "uuid",
@@ -199,6 +377,15 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
+          "mappedType": "uuid"
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
           "mappedType": "uuid"
         }
       },
@@ -239,6 +426,18 @@
           ],
           "referencedTableName": "public.thumbnails",
           "deleteRule": "set null",
+          "updateRule": "cascade"
+        },
+        "articles_collection_id_foreign": {
+          "constraintName": "articles_collection_id_foreign",
+          "columnNames": [
+            "collection_id"
+          ],
+          "localTableName": "public.articles",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.article_collections",
           "updateRule": "cascade"
         }
       },

--- a/backend/src/database/migrations/.snapshot-wiki-feats-db.json
+++ b/backend/src/database/migrations/.snapshot-wiki-feats-db.json
@@ -411,16 +411,6 @@
       "schema": "public",
       "indexes": [
         {
-          "columnNames": [
-            "thumbnail_id"
-          ],
-          "composite": false,
-          "keyName": "articles_thumbnail_id_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
           "keyName": "articles_pkey",
           "columnNames": [
             "id"

--- a/backend/src/database/migrations/20240328203932-add-article-collections-and-language-tables.ts
+++ b/backend/src/database/migrations/20240328203932-add-article-collections-and-language-tables.ts
@@ -1,0 +1,46 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240328203932_add_article_collections_and_language_tables extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "languages" ("id" uuid not null, "name" varchar(255) not null, "code" varchar(255) not null, "created_at" timestamptz not null, "updated_at" timestamptz not null, "deleted_at" timestamptz null, constraint "languages_pkey" primary key ("id"));',
+    );
+
+    this.addSql(
+      'create table "article_collections" ("id" uuid not null, "featured_date" date not null, "available_articles" int not null, "total_articles" int not null, "language_id" uuid not null, "created_at" timestamptz not null, "updated_at" timestamptz not null, "deleted_at" timestamptz null, constraint "article_collections_pkey" primary key ("id"));',
+    );
+
+    this.addSql(
+      'alter table "article_collections" add constraint "article_collections_language_id_foreign" foreign key ("language_id") references "languages" ("id") on update cascade;',
+    );
+
+    this.addSql('alter table "articles" drop column "featured_date";');
+
+    this.addSql(
+      'alter table "articles" add column "collection_id" uuid not null;',
+    );
+    this.addSql(
+      'alter table "articles" add constraint "articles_collection_id_foreign" foreign key ("collection_id") references "article_collections" ("id") on update cascade;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "article_collections" drop constraint "article_collections_language_id_foreign";',
+    );
+
+    this.addSql(
+      'alter table "articles" drop constraint "articles_collection_id_foreign";',
+    );
+
+    this.addSql('drop table if exists "languages" cascade;');
+
+    this.addSql('drop table if exists "article_collections" cascade;');
+
+    this.addSql('alter table "articles" drop column "collection_id";');
+
+    this.addSql(
+      'alter table "articles" add column "featured_date" date not null;',
+    );
+  }
+}

--- a/backend/src/database/migrations/20240328220159-add-extract-html-and-context-columns-to-article-table.ts
+++ b/backend/src/database/migrations/20240328220159-add-extract-html-and-context-columns-to-article-table.ts
@@ -1,0 +1,14 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240328220159_add_extract_html_and_context_columns_to_article_table extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "articles" add column "extract_html" text not null, add column "context" text not null;',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('alter table "articles" drop column "extract_html";');
+    this.addSql('alter table "articles" drop column "context";');
+  }
+}

--- a/backend/src/database/migrations/20240328231431-set-article-context-as-nullable.ts
+++ b/backend/src/database/migrations/20240328231431-set-article-context-as-nullable.ts
@@ -1,0 +1,17 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240328231431_set_article_context_as_nullable extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "articles" alter column "context" type text using ("context"::text);',
+    );
+    this.addSql('alter table "articles" alter column "context" drop not null;');
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "articles" alter column "context" type text using ("context"::text);',
+    );
+    this.addSql('alter table "articles" alter column "context" set not null;');
+  }
+}

--- a/backend/src/database/migrations/20240329022800-change-article-thumbnail-relationship-to-many-to-one.ts
+++ b/backend/src/database/migrations/20240329022800-change-article-thumbnail-relationship-to-many-to-one.ts
@@ -1,0 +1,15 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240329022800_change_article_thumbnail_relationship_to_many_to_one extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'alter table "articles" drop constraint "articles_thumbnail_id_unique";',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql(
+      'alter table "articles" add constraint "articles_thumbnail_id_unique" unique ("thumbnail_id");',
+    );
+  }
+}

--- a/backend/src/mocks/article-collection.mocks.ts
+++ b/backend/src/mocks/article-collection.mocks.ts
@@ -1,0 +1,17 @@
+import { faker } from "@faker-js/faker";
+import { ArticleCollection } from "../database/entities/article-collection.entity";
+import { createLanguageMock } from "./language.mocks";
+
+export const createArticleCollectionMock = (): ArticleCollection => {
+  return {
+    id: faker.string.uuid(),
+    availableArticles: faker.number.int({ min: 1, max: 1000 }),
+    totalArticles: faker.number.int({ min: 1, max: 1000 }),
+    featuredDate: faker.date.recent(),
+    language: createLanguageMock(),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+    deletedAt: null,
+    articles: [],
+  };
+};

--- a/backend/src/mocks/article.mocks.ts
+++ b/backend/src/mocks/article.mocks.ts
@@ -6,10 +6,12 @@ export const createArticleMock = (): Article => ({
   id: faker.string.uuid(),
   title: faker.lorem.words(),
   extract: faker.lorem.paragraph(),
+  extractHtml: faker.lorem.paragraph(),
+  context: faker.lorem.paragraph(),
   articleUrl: faker.internet.url(),
   articleType: faker.helpers.arrayElement(Object.values(ArticleType)),
   wikipediaPageId: faker.number.int({ min: 1, max: 1000 }),
-  featuredDate: faker.date.recent(),
+  articleCollection: null,
   thumbnail: {
     id: faker.string.uuid(),
     url: faker.internet.url(),

--- a/backend/src/mocks/article.mocks.ts
+++ b/backend/src/mocks/article.mocks.ts
@@ -20,6 +20,7 @@ export const createArticleMock = (): Article => ({
     createdAt: faker.date.past(),
     updatedAt: faker.date.recent(),
     deletedAt: null,
+    articles: null,
   },
   createdAt: faker.date.past(),
   updatedAt: faker.date.recent(),

--- a/backend/src/mocks/language.mocks.ts
+++ b/backend/src/mocks/language.mocks.ts
@@ -1,0 +1,14 @@
+import { faker } from "@faker-js/faker";
+import { Language } from "../database/entities/language.entity";
+
+export const createLanguageMock = (): Language => {
+  return {
+    id: faker.string.uuid(),
+    name: faker.string.alphanumeric({ length: { min: 5, max: 25 } }),
+    code: faker.string.alpha({ length: 2 }),
+    createdAt: faker.date.past(),
+    updatedAt: faker.date.recent(),
+    deletedAt: null,
+    articleCollections: [],
+  };
+};

--- a/backend/src/mocks/libre-translate-api.mocks.ts
+++ b/backend/src/mocks/libre-translate-api.mocks.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker/locale/af_ZA";
+import {
+  AvailableTranslation,
+  GetAvailableLanguagesResponse,
+} from "../modules/translate/types/libre-translate-api-response.types";
+
+export const createGetAvailableLanguagesResponseMock =
+  (): GetAvailableLanguagesResponse => {
+    return Array.from({ length: 10 }, () => createAvailableTranslationMock());
+  };
+
+export const createAvailableTranslationMock = (): AvailableTranslation => ({
+  code: faker.string.alpha({ length: 2 }),
+  name: faker.lorem.word(),
+  targets: Array.from({ length: 5 }, () => faker.string.alpha()),
+});
+
+export const createGetTranslatedTextResponseMock = () => ({
+  translatedText: Array.from({ length: 5 }, () => faker.lorem.sentence()),
+});

--- a/backend/src/modules/article/article.module.ts
+++ b/backend/src/modules/article/article.module.ts
@@ -3,6 +3,7 @@ import { Module } from "@nestjs/common";
 import { ArticleCollection } from "../../database/entities/article-collection.entity";
 import { Article } from "../../database/entities/article.entity";
 import { Language } from "../../database/entities/language.entity";
+import { TranslateModule } from "../translate/translate.module";
 import { WikipediaModule } from "../wikipedia/wikipedia.module";
 import { ArticleService } from "./article.service";
 
@@ -10,6 +11,7 @@ import { ArticleService } from "./article.service";
   imports: [
     MikroOrmModule.forFeature([Article, ArticleCollection, Language]),
     WikipediaModule,
+    TranslateModule,
   ],
   providers: [ArticleService],
   exports: [ArticleService],

--- a/backend/src/modules/article/article.module.ts
+++ b/backend/src/modules/article/article.module.ts
@@ -1,11 +1,16 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { Module } from "@nestjs/common";
+import { ArticleCollection } from "../../database/entities/article-collection.entity";
 import { Article } from "../../database/entities/article.entity";
+import { Language } from "../../database/entities/language.entity";
 import { WikipediaModule } from "../wikipedia/wikipedia.module";
 import { ArticleService } from "./article.service";
 
 @Module({
-  imports: [MikroOrmModule.forFeature([Article]), WikipediaModule],
+  imports: [
+    MikroOrmModule.forFeature([Article, ArticleCollection, Language]),
+    WikipediaModule,
+  ],
   providers: [ArticleService],
   exports: [ArticleService],
 })

--- a/backend/src/modules/article/article.service.spec.ts
+++ b/backend/src/modules/article/article.service.spec.ts
@@ -2,7 +2,11 @@ import { createMock } from "@golevelup/ts-jest";
 import { getRepositoryToken } from "@mikro-orm/nestjs";
 import { Test, TestingModule } from "@nestjs/testing";
 import { BaseRepository } from "../../common/database/base.repository";
+import { ArticleCollection } from "../../database/entities/article-collection.entity";
 import { Article } from "../../database/entities/article.entity";
+import { Language } from "../../database/entities/language.entity";
+import { createArticleCollectionMock } from "../../mocks/article-collection.mocks";
+import { createLanguageMock } from "../../mocks/language.mocks";
 import { createWikipediaArticleMock } from "../../mocks/wikipedia-article";
 import { WikipediaService } from "../wikipedia/wikipedia.service";
 import { ArticleService } from "./article.service";
@@ -15,6 +19,15 @@ describe("ArticleService", () => {
     create: jest.fn(),
     getEntityManager: jest.fn().mockReturnValue({ flush: jest.fn() }),
   });
+  const mockArticleCollectionRepository = createMock<
+    BaseRepository<ArticleCollection>
+  >({
+    findOne: jest.fn(),
+    create: jest.fn(),
+  });
+  const mockLanguageRepository = createMock<BaseRepository<Language>>({
+    findOneOrFail: jest.fn(),
+  });
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -23,6 +36,14 @@ describe("ArticleService", () => {
         {
           provide: getRepositoryToken(Article),
           useValue: mockArticleRepository,
+        },
+        {
+          provide: getRepositoryToken(ArticleCollection),
+          useValue: mockArticleCollectionRepository,
+        },
+        {
+          provide: getRepositoryToken(Language),
+          useValue: mockLanguageRepository,
         },
         {
           provide: WikipediaService,
@@ -46,33 +67,69 @@ describe("ArticleService", () => {
     mockWikipediaService.fetchFeaturedContents.mockResolvedValue(
       mockedArticles,
     );
+    mockArticleCollectionRepository.create.mockReturnValue(
+      createArticleCollectionMock(),
+    );
+    mockArticleCollectionRepository.findOne.mockResolvedValue(undefined);
+    mockLanguageRepository.findOneOrFail.mockResolvedValue(
+      createLanguageMock(),
+    );
 
     await service.importArticles("2021-09-01");
 
     expect(mockWikipediaService.fetchFeaturedContents).toHaveBeenCalled();
+    expect(mockArticleCollectionRepository.create).toHaveBeenCalled();
+    expect(mockLanguageRepository.findOneOrFail).toHaveBeenCalled();
     expect(mockArticleRepository.create).toHaveBeenCalled();
     expect(mockArticleRepository.getEntityManager().flush).toHaveBeenCalled();
   });
 
   it("should get articles by date", async () => {
+    const mockArticleCollection = createArticleCollectionMock();
+
+    mockArticleCollectionRepository.findOne.mockResolvedValue(
+      mockArticleCollection,
+    );
+
     await service.getArticlesByDate("2021-09-01");
 
     expect(mockArticleRepository.findPaginated).toHaveBeenCalled();
   });
 
-  it("should resolve to true if articles from date provided exist", async () => {
-    mockArticleRepository.count.mockResolvedValue(1);
+  it("should resolve to true if the article collection with the feature date provided exists", async () => {
+    const mockArticleCollection = createArticleCollectionMock();
+    mockArticleCollection.availableArticles = 100;
 
-    expect(service.areDateArticlesImported("2021-09-01")).resolves.toBe(true);
+    mockArticleCollectionRepository.findOne.mockResolvedValue(
+      mockArticleCollection,
+    );
 
-    expect(mockArticleRepository.count).toHaveBeenCalled();
+    const result = await service.areDateArticlesImported("2021-09-01");
+
+    expect(result).toBe(true);
+    expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();
   });
 
-  it("should resolve to false if articles from date provided do not exist", async () => {
-    mockArticleRepository.count.mockResolvedValue(0);
+  it("should resolve to false if the article collection with the feature date provided does not have available articles", async () => {
+    const mockArticleCollection = createArticleCollectionMock();
+    mockArticleCollection.availableArticles = 0;
 
-    expect(service.areDateArticlesImported("2021-09-01")).resolves.toBe(false);
+    mockArticleCollectionRepository.findOne.mockResolvedValue(
+      mockArticleCollection,
+    );
 
-    expect(mockArticleRepository.count).toHaveBeenCalled();
+    const result = await service.areDateArticlesImported("2021-09-01");
+
+    expect(result).toBe(false);
+    expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();
+  });
+
+  it("should resolve to false if the article collection with the feature date provided does not exist", async () => {
+    mockArticleCollectionRepository.findOne.mockResolvedValue(undefined);
+
+    const result = await service.areDateArticlesImported("2021-09-01");
+
+    expect(result).toBe(false);
+    expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/article/article.service.spec.ts
+++ b/backend/src/modules/article/article.service.spec.ts
@@ -104,7 +104,7 @@ describe("ArticleService", () => {
       mockArticleCollection,
     );
 
-    const result = await service.areDateArticlesImported("2021-09-01");
+    const result = await service.getArticleCollectionStatus("2021-09-01");
 
     expect(result).toBe(true);
     expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();
@@ -118,7 +118,7 @@ describe("ArticleService", () => {
       mockArticleCollection,
     );
 
-    const result = await service.areDateArticlesImported("2021-09-01");
+    const result = await service.getArticleCollectionStatus("2021-09-01");
 
     expect(result).toBe(false);
     expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();
@@ -127,7 +127,7 @@ describe("ArticleService", () => {
   it("should resolve to false if the article collection with the feature date provided does not exist", async () => {
     mockArticleCollectionRepository.findOne.mockResolvedValue(undefined);
 
-    const result = await service.areDateArticlesImported("2021-09-01");
+    const result = await service.getArticleCollectionStatus("2021-09-01");
 
     expect(result).toBe(false);
     expect(mockArticleCollectionRepository.findOne).toHaveBeenCalled();

--- a/backend/src/modules/article/article.service.ts
+++ b/backend/src/modules/article/article.service.ts
@@ -69,7 +69,7 @@ export class ArticleService {
     });
 
     const articles = await this.articleRepository.findPaginated(
-      { page: options?.page ?? 1, pageSize: options.pageSize ?? 5 },
+      { page: options?.page ?? 1, pageSize: options?.pageSize ?? 5 },
       { articleCollection, deletedAt: { $exists: false } },
       { orderBy: { articleType: QueryOrder.ASC } },
     );
@@ -83,6 +83,8 @@ export class ArticleService {
       deletedAt: { $exists: false },
     });
 
-    return articleCollection && articleCollection.availableArticles !== 0;
+    return Boolean(
+      articleCollection && articleCollection.availableArticles !== 0,
+    );
   }
 }

--- a/backend/src/modules/article/article.service.ts
+++ b/backend/src/modules/article/article.service.ts
@@ -3,7 +3,9 @@ import { InjectRepository } from "@mikro-orm/nestjs";
 import { Injectable } from "@nestjs/common";
 import { PaginatedFindResult } from "../../common/@types/types/pagination.types";
 import { BaseRepository } from "../../common/database/base.repository";
+import { ArticleCollection } from "../../database/entities/article-collection.entity";
 import { Article } from "../../database/entities/article.entity";
+import { Language } from "../../database/entities/language.entity";
 import { WikipediaService } from "../wikipedia/wikipedia.service";
 import { GetArticlesByDateOptions } from "./types/get-articles-by-date-options.types";
 
@@ -12,20 +14,38 @@ export class ArticleService {
   constructor(
     @InjectRepository(Article)
     private readonly articleRepository: BaseRepository<Article>,
+    @InjectRepository(ArticleCollection)
+    private readonly articleCollectionRepository: BaseRepository<ArticleCollection>,
+    @InjectRepository(Language)
+    private readonly languageRepository: BaseRepository<Language>,
+
     private readonly wikipediaService: WikipediaService,
   ) {}
 
   async importArticles(date: string) {
     const articles = await this.wikipediaService.fetchFeaturedContents(date);
 
-    articles.map((article) => {
+    const englishLanguage = await this.languageRepository.findOneOrFail({
+      code: "en",
+    });
+
+    const articleCollection = this.articleCollectionRepository.create({
+      featuredDate: new Date(date),
+      availableArticles: articles.length,
+      totalArticles: articles.length,
+      language: englishLanguage,
+    });
+
+    articles.forEach((article) => {
       return this.articleRepository.create({
         title: article.titles.normalized,
         extract: article.extract,
+        extractHtml: article.extract_html,
+        context: article.story ?? article.text,
         articleUrl: article.content_urls.desktop.page,
         articleType: article.articleType,
         wikipediaPageId: article.pageid,
-        featuredDate: new Date(date),
+        articleCollection,
         ...(article.thumbnail?.source && {
           thumbnail: {
             url: article.thumbnail.source,
@@ -43,23 +63,26 @@ export class ArticleService {
     date: string,
     options?: GetArticlesByDateOptions,
   ): Promise<PaginatedFindResult<Article>> {
-    return await this.articleRepository.findPaginated(
-      { page: options?.page ?? 1, pageSize: options?.pageSize ?? 5 },
-      { featuredDate: new Date(date) },
-      {
-        orderBy: {
-          articleType: QueryOrder.ASC,
-        },
-      },
-    );
-  }
-
-  async areDateArticlesImported(date: string) {
-    const articleCount = await this.articleRepository.count({
+    const articleCollection = await this.articleCollectionRepository.findOne({
       featuredDate: new Date(date),
       deletedAt: { $exists: false },
     });
 
-    return articleCount > 0;
+    const articles = await this.articleRepository.findPaginated(
+      { page: options?.page ?? 1, pageSize: options.pageSize ?? 5 },
+      { articleCollection, deletedAt: { $exists: false } },
+      { orderBy: { articleType: QueryOrder.ASC } },
+    );
+
+    return articles;
+  }
+
+  async areDateArticlesImported(date: string) {
+    const articleCollection = await this.articleCollectionRepository.findOne({
+      featuredDate: new Date(date),
+      deletedAt: { $exists: false },
+    });
+
+    return articleCollection && articleCollection.availableArticles !== 0;
   }
 }

--- a/backend/src/modules/article/article.service.ts
+++ b/backend/src/modules/article/article.service.ts
@@ -149,6 +149,7 @@ export class ArticleService {
       (article) => article.wikipediaPageId,
     );
 
+    // We fork here to avoid returning article collections with its articles
     const forkedEntityManager = this.entityManager.fork();
     const forkedArticleRepository = forkedEntityManager.getRepository(Article);
 

--- a/backend/src/modules/article/article.service.ts
+++ b/backend/src/modules/article/article.service.ts
@@ -129,6 +129,8 @@ export class ArticleService {
       });
     });
 
+    articleCollection.availableArticles += translatedArticles.length;
+
     await this.entityManager.flush();
   }
 

--- a/backend/src/modules/article/enum/article-collection-status.enum.ts
+++ b/backend/src/modules/article/enum/article-collection-status.enum.ts
@@ -1,0 +1,6 @@
+export enum ArticleCollectionStatus {
+  HasAllArticles = "has-all-articles",
+  ImportingRequired = "importing-required",
+  TranslationRequired = "translation-required",
+  ImportingAndTranslationRequired = "importing-and-translation-required",
+}

--- a/backend/src/modules/article/types/get-article-options.types.ts
+++ b/backend/src/modules/article/types/get-article-options.types.ts
@@ -1,0 +1,6 @@
+import { Pagination } from "../../../common/@types/types/pagination.types";
+
+export type GetArticleOptions = Pagination & {
+  date: string;
+  languageCode: string;
+};

--- a/backend/src/modules/article/types/get-articles-by-date-options.types.ts
+++ b/backend/src/modules/article/types/get-articles-by-date-options.types.ts
@@ -1,3 +1,0 @@
-import { Pagination } from "../../../common/@types/types/pagination.types";
-
-export type GetArticlesByDateOptions = Partial<Pagination>;

--- a/backend/src/modules/feed/dto/get-feed-by-date.param.dto.ts
+++ b/backend/src/modules/feed/dto/get-feed-by-date.param.dto.ts
@@ -3,7 +3,7 @@ import { IsISO8601 } from "class-validator";
 import { startOfToday } from "date-fns";
 import { MaxIsoDate } from "../../../common/decorators/max-iso-date.decorator";
 
-export class GetFeedParamsDto {
+export class GetFeedByDateParamsDto {
   @ApiProperty({
     type: "string",
     description: "Date in ISO8601 format without time",

--- a/backend/src/modules/feed/dto/get-supported-feed-languages.response.dto.ts
+++ b/backend/src/modules/feed/dto/get-supported-feed-languages.response.dto.ts
@@ -1,0 +1,3 @@
+import { Language } from "../../../database/entities/language.entity";
+
+export class GetSupportedLanguagesResponseDto extends Array<Language> {}

--- a/backend/src/modules/feed/dto/get-translated-feed.param.dto.ts
+++ b/backend/src/modules/feed/dto/get-translated-feed.param.dto.ts
@@ -1,25 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
-import {
-  IsAlpha,
-  IsISO8601,
-  IsLowercase,
-  IsString,
-  Length,
-} from "class-validator";
-import { startOfToday } from "date-fns";
-import { MaxIsoDate } from "../../../common/decorators/max-iso-date.decorator";
+import { IsAlpha, IsLowercase, IsString, Length } from "class-validator";
 
 export class GetTranslatedFeedParamsDto {
-  @ApiProperty({
-    type: "string",
-    description: "Date in ISO8601 format without time",
-  })
-  @MaxIsoDate(() => startOfToday(), {
-    message: "date must not be greater than today",
-  })
-  @IsISO8601({ strict: true })
-  date: string;
-
   @ApiProperty({
     type: "string",
     description: "Language code",

--- a/backend/src/modules/feed/dto/get-translated-feed.param.dto.ts
+++ b/backend/src/modules/feed/dto/get-translated-feed.param.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsAlpha,
+  IsISO8601,
+  IsLowercase,
+  IsString,
+  Length,
+} from "class-validator";
+import { startOfToday } from "date-fns";
+import { MaxIsoDate } from "../../../common/decorators/max-iso-date.decorator";
+
+export class GetTranslatedFeedParamsDto {
+  @ApiProperty({
+    type: "string",
+    description: "Date in ISO8601 format without time",
+  })
+  @MaxIsoDate(() => startOfToday(), {
+    message: "date must not be greater than today",
+  })
+  @IsISO8601({ strict: true })
+  date: string;
+
+  @ApiProperty({
+    type: "string",
+    description: "Language code",
+  })
+  @Length(2, 2)
+  @IsLowercase()
+  @IsAlpha()
+  @IsString()
+  languageCode: string;
+}

--- a/backend/src/modules/feed/feed.controller.spec.ts
+++ b/backend/src/modules/feed/feed.controller.spec.ts
@@ -1,24 +1,29 @@
 import { createMock } from "@golevelup/ts-jest";
 import { Test, TestingModule } from "@nestjs/testing";
-import { startOfToday } from "date-fns";
-import { getIsoDate } from "../../common/helpers/iso-date.utils";
 import { createArticleMock } from "../../mocks/article.mocks";
+import { createLanguageMock } from "../../mocks/language.mocks";
 import { createPaginatedFindResultMock } from "../../mocks/pagination.mocks";
 import { FeedController } from "./feed.controller";
 import { FeedService } from "./feed.service";
 
 describe("FeedController", () => {
   let controller: FeedController;
-  const mockFeedService = createMock<FeedService>({
-    getFeedArticles: jest.fn(),
-  });
+  let mockFeedService;
 
   const articles = Array.from({ length: 12 }, () => createArticleMock());
   const paginatedArticles = createPaginatedFindResultMock(articles);
 
-  const defaultOptions = { page: undefined, pageSize: undefined };
+  const languages = Array.from({ length: 3 }, () => createLanguageMock());
 
   beforeEach(async () => {
+    mockFeedService = createMock<FeedService>({
+      getFeedArticles: jest.fn(),
+      getSupportedFeedLanguages: jest.fn(),
+    });
+
+    mockFeedService.getFeedArticles.mockResolvedValue(paginatedArticles);
+    mockFeedService.getSupportedFeedLanguages.mockResolvedValue(languages);
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FeedController],
       providers: [{ provide: FeedService, useValue: mockFeedService }],
@@ -32,40 +37,105 @@ describe("FeedController", () => {
   });
 
   it("should get today's feed articles", async () => {
-    const today = getIsoDate(startOfToday());
-    mockFeedService.getFeedArticles.mockResolvedValue(paginatedArticles);
+    const query = {};
 
-    const result = await controller.getCurrentFeed({});
+    const result = await controller.getCurrentFeed(query);
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith(
-      today,
-      defaultOptions,
-    );
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({ ...query });
+  });
+
+  it("should get today's feed articles with pagination options", async () => {
+    const query = { page: 1, pageSize: 10 };
+
+    const result = await controller.getCurrentFeed(query);
+    expect(result).toEqual(paginatedArticles);
+
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({ ...query });
   });
 
   it("should get feed articles by date", async () => {
-    const date = "2021-09-01";
-    mockFeedService.getFeedArticles.mockResolvedValue(paginatedArticles);
+    const params = { date: "2021-09-01" };
+    const query = {};
 
-    const result = await controller.getFeedByDate({ date }, {});
+    const result = await controller.getFeedByDate(params, query);
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith(
-      date,
-      defaultOptions,
-    );
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
   });
 
   it("should get feed articles by date with pagination options", async () => {
-    const date = "2021-09-01";
-    const options = { page: 1, pageSize: 10 };
+    const params = { date: "2021-09-01" };
+    const query = { page: 1, pageSize: 10 };
 
-    mockFeedService.getFeedArticles.mockResolvedValue(paginatedArticles);
-
-    const result = await controller.getFeedByDate({ date }, options);
+    const result = await controller.getFeedByDate(params, query);
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith(date, options);
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
+  });
+
+  it("should get today's feed articles in the given language", async () => {
+    const params = { languageCode: "es" };
+    const query = {};
+
+    const result = await controller.getTranslatedFeed(params, query);
+    expect(result).toEqual(paginatedArticles);
+
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
+  });
+
+  it("should get today's feed articles with pagination options in the given language", async () => {
+    const params = { languageCode: "es" };
+    const query = { page: 1, pageSize: 10 };
+
+    const result = await controller.getTranslatedFeed(params, query);
+    expect(result).toEqual(paginatedArticles);
+
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
+  });
+
+  it("should get feed articles by date", async () => {
+    const params = { languageCode: "es", date: "2021-09-01" };
+    const query = {};
+
+    const result = await controller.getTranslatedFeedByDate(params, query);
+    expect(result).toEqual(paginatedArticles);
+
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
+  });
+
+  it("should get feed articles by date with pagination options", async () => {
+    const params = { languageCode: "es", date: "2021-09-01" };
+    const query = { page: 1, pageSize: 10 };
+
+    const result = await controller.getTranslatedFeedByDate(params, query);
+    expect(result).toEqual(paginatedArticles);
+
+    expect(mockFeedService.getFeedArticles).toHaveBeenCalledWith({
+      ...params,
+      ...query,
+    });
+  });
+
+  it("should get supported feed languages", async () => {
+    const result = await controller.getSupportedFeedLanguages();
+    expect(result).toEqual(languages);
+
+    expect(mockFeedService.getSupportedFeedLanguages).toHaveBeenCalled();
   });
 });

--- a/backend/src/modules/feed/feed.controller.ts
+++ b/backend/src/modules/feed/feed.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get, Param, Query } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { GetFeedParamsDto } from "./dto/get-feed.param.dto";
+import { GetFeedByDateParamsDto } from "./dto/get-feed-by-date.param.dto";
 import { GetFeedQueryDto } from "./dto/get-feed.query.dto";
 import { GetFeedResponseDto } from "./dto/get-feed.response.dto";
 import { GetTranslatedFeedParamsDto } from "./dto/get-translated-feed.param.dto";
@@ -11,18 +11,7 @@ import { FeedService } from "./feed.service";
 export class FeedController {
   constructor(private readonly feedService: FeedService) {}
 
-  @Get()
-  @ApiOperation({ summary: "Get today's featured Wikipedia articles" })
-  @ApiResponse({ type: GetFeedResponseDto })
-  async getCurrentFeed(
-    @Query() query: GetFeedQueryDto,
-  ): Promise<GetFeedResponseDto> {
-    return await this.feedService.getFeedArticles({
-      ...query,
-    });
-  }
-
-  @Get("/translate/:languageCode")
+  @Get("translate/:languageCode")
   @ApiOperation({
     summary: "Get featured Wikipedia articles in the given language",
   })
@@ -37,11 +26,22 @@ export class FeedController {
     });
   }
 
-  @Get("/:date")
+  @Get()
+  @ApiOperation({ summary: "Get today's featured Wikipedia articles" })
+  @ApiResponse({ type: GetFeedResponseDto })
+  async getCurrentFeed(
+    @Query() query: GetFeedQueryDto,
+  ): Promise<GetFeedResponseDto> {
+    return await this.feedService.getFeedArticles({
+      ...query,
+    });
+  }
+
+  @Get(":date")
   @ApiOperation({ summary: "Get featured Wikipedia articles from a past date" })
   @ApiResponse({ type: GetFeedResponseDto })
   async getFeedByDate(
-    @Param() params: GetFeedParamsDto,
+    @Param() params: GetFeedByDateParamsDto,
     @Query() query: GetFeedQueryDto,
   ): Promise<GetFeedResponseDto> {
     return await this.feedService.getFeedArticles({
@@ -50,13 +50,13 @@ export class FeedController {
     });
   }
 
-  @Get("/:date/translate/:languageCode")
+  @Get(":date/translate/:languageCode")
   @ApiOperation({
     summary: "Get featured Wikipedia articles in the given language",
   })
   @ApiResponse({ type: GetFeedResponseDto })
   async getTranslatedFeedByDate(
-    @Param() params: GetTranslatedFeedParamsDto,
+    @Param() params: GetTranslatedFeedParamsDto & GetFeedByDateParamsDto,
     @Query() query: GetFeedQueryDto,
   ): Promise<GetFeedResponseDto> {
     return await this.feedService.getFeedArticles({

--- a/backend/src/modules/feed/feed.controller.ts
+++ b/backend/src/modules/feed/feed.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { GetFeedParamsDto } from "./dto/get-feed.param.dto";
 import { GetFeedQueryDto } from "./dto/get-feed.query.dto";
 import { GetFeedResponseDto } from "./dto/get-feed.response.dto";
+import { GetTranslatedFeedParamsDto } from "./dto/get-translated-feed.param.dto";
 import { FeedService } from "./feed.service";
 
 @ApiTags("feed")
@@ -11,7 +12,7 @@ export class FeedController {
   constructor(private readonly feedService: FeedService) {}
 
   @Get()
-  @ApiOperation({ summary: "Get today's featured wikipedia articles" })
+  @ApiOperation({ summary: "Get today's featured Wikipedia articles" })
   @ApiResponse({ type: GetFeedResponseDto })
   async getCurrentFeed(
     @Query() query: GetFeedQueryDto,
@@ -21,17 +22,45 @@ export class FeedController {
     });
   }
 
+  @Get("/translate/:languageCode")
+  @ApiOperation({
+    summary: "Get featured Wikipedia articles in the given language",
+  })
+  @ApiResponse({ type: GetFeedResponseDto })
+  async getTranslatedFeed(
+    @Param() params: GetTranslatedFeedParamsDto,
+    @Query() query: GetFeedQueryDto,
+  ): Promise<GetFeedResponseDto> {
+    return await this.feedService.getFeedArticles({
+      ...params,
+      ...query,
+    });
+  }
+
   @Get("/:date")
-  @ApiOperation({ summary: "Get featured wikipedia articles from a past date" })
+  @ApiOperation({ summary: "Get featured Wikipedia articles from a past date" })
   @ApiResponse({ type: GetFeedResponseDto })
   async getFeedByDate(
     @Param() params: GetFeedParamsDto,
     @Query() query: GetFeedQueryDto,
   ): Promise<GetFeedResponseDto> {
-    const { date } = params;
-
     return await this.feedService.getFeedArticles({
-      date,
+      ...params,
+      ...query,
+    });
+  }
+
+  @Get("/:date/translate/:languageCode")
+  @ApiOperation({
+    summary: "Get featured Wikipedia articles in the given language",
+  })
+  @ApiResponse({ type: GetFeedResponseDto })
+  async getTranslatedFeedByDate(
+    @Param() params: GetTranslatedFeedParamsDto,
+    @Query() query: GetFeedQueryDto,
+  ): Promise<GetFeedResponseDto> {
+    return await this.feedService.getFeedArticles({
+      ...params,
       ...query,
     });
   }

--- a/backend/src/modules/feed/feed.controller.ts
+++ b/backend/src/modules/feed/feed.controller.ts
@@ -3,6 +3,7 @@ import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { GetFeedByDateParamsDto } from "./dto/get-feed-by-date.param.dto";
 import { GetFeedQueryDto } from "./dto/get-feed.query.dto";
 import { GetFeedResponseDto } from "./dto/get-feed.response.dto";
+import { GetSupportedLanguagesResponseDto } from "./dto/get-supported-feed-languages.response.dto";
 import { GetTranslatedFeedParamsDto } from "./dto/get-translated-feed.param.dto";
 import { FeedService } from "./feed.service";
 
@@ -10,6 +11,24 @@ import { FeedService } from "./feed.service";
 @Controller("feed")
 export class FeedController {
   constructor(private readonly feedService: FeedService) {}
+
+  @Get()
+  @ApiOperation({ summary: "Get today's featured Wikipedia articles" })
+  @ApiResponse({ type: GetFeedResponseDto })
+  async getCurrentFeed(
+    @Query() query: GetFeedQueryDto,
+  ): Promise<GetFeedResponseDto> {
+    return await this.feedService.getFeedArticles({
+      ...query,
+    });
+  }
+
+  @Get("languages")
+  @ApiOperation({ summary: "Get supported feed languages" })
+  @ApiResponse({ status: 200, type: GetSupportedLanguagesResponseDto })
+  async getSupportedFeedLanguages(): Promise<GetSupportedLanguagesResponseDto> {
+    return await this.feedService.getSupportedFeedLanguages();
+  }
 
   @Get("translate/:languageCode")
   @ApiOperation({
@@ -22,17 +41,6 @@ export class FeedController {
   ): Promise<GetFeedResponseDto> {
     return await this.feedService.getFeedArticles({
       ...params,
-      ...query,
-    });
-  }
-
-  @Get()
-  @ApiOperation({ summary: "Get today's featured Wikipedia articles" })
-  @ApiResponse({ type: GetFeedResponseDto })
-  async getCurrentFeed(
-    @Query() query: GetFeedQueryDto,
-  ): Promise<GetFeedResponseDto> {
-    return await this.feedService.getFeedArticles({
       ...query,
     });
   }

--- a/backend/src/modules/feed/feed.controller.ts
+++ b/backend/src/modules/feed/feed.controller.ts
@@ -1,7 +1,5 @@
 import { Controller, Get, Param, Query } from "@nestjs/common";
 import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { startOfToday } from "date-fns";
-import { getIsoDate } from "../../common/helpers/iso-date.utils";
 import { GetFeedParamsDto } from "./dto/get-feed.param.dto";
 import { GetFeedQueryDto } from "./dto/get-feed.query.dto";
 import { GetFeedResponseDto } from "./dto/get-feed.response.dto";
@@ -18,14 +16,9 @@ export class FeedController {
   async getCurrentFeed(
     @Query() query: GetFeedQueryDto,
   ): Promise<GetFeedResponseDto> {
-    const today = getIsoDate(startOfToday());
-
-    const options = {
-      page: query?.page,
-      pageSize: query?.pageSize,
-    };
-
-    return await this.feedService.getFeedArticles(today, options);
+    return await this.feedService.getFeedArticles({
+      ...query,
+    });
   }
 
   @Get("/:date")
@@ -37,11 +30,9 @@ export class FeedController {
   ): Promise<GetFeedResponseDto> {
     const { date } = params;
 
-    const options = {
-      page: query?.page,
-      pageSize: query?.pageSize,
-    };
-
-    return await this.feedService.getFeedArticles(date, options);
+    return await this.feedService.getFeedArticles({
+      date,
+      ...query,
+    });
   }
 }

--- a/backend/src/modules/feed/feed.module.ts
+++ b/backend/src/modules/feed/feed.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
 import { ArticleModule } from "../article/article.module";
+import { TranslateModule } from "../translate/translate.module";
 import { FeedController } from "./feed.controller";
 import { FeedService } from "./feed.service";
 
 @Module({
-  imports: [ArticleModule],
+  imports: [ArticleModule, TranslateModule],
   controllers: [FeedController],
   providers: [FeedService],
 })

--- a/backend/src/modules/feed/feed.service.spec.ts
+++ b/backend/src/modules/feed/feed.service.spec.ts
@@ -1,26 +1,66 @@
 import { createMock } from "@golevelup/ts-jest";
 import { Test, TestingModule } from "@nestjs/testing";
+import {
+  expectCallsInMethods,
+  expectNoCallsInMethods,
+} from "../../common/helpers/expect.utils";
 import { createArticleMock } from "../../mocks/article.mocks";
+import { createLanguageMock } from "../../mocks/language.mocks";
 import { createPaginatedFindResultMock } from "../../mocks/pagination.mocks";
 import { ArticleService } from "../article/article.service";
+import { TranslateService } from "../translate/translate.service";
 import { FeedService } from "./feed.service";
 
 describe("FeedService", () => {
   let service: FeedService;
-  const mockArticleService = createMock<ArticleService>({
-    getArticleCollectionStatus: jest.fn(),
-    getArticlesByDate: jest.fn(),
-    importArticles: jest.fn(),
-  });
+  let mockArticleService;
+  let mockTranslateService;
 
   const articles = Array.from({ length: 12 }, () => createArticleMock());
   const paginatedArticles = createPaginatedFindResultMock(articles);
 
+  const setResolvedValues = ({
+    isTranslated,
+    isImported,
+    isLanguageSupported,
+    translatedArticlesSearchResult,
+    importedArticlesSearchResult,
+  }: Partial<{
+    [key: string]: any;
+  }>) => {
+    mockTranslateService.checkIfTranslationLanguageIsSupported.mockResolvedValue(
+      isLanguageSupported,
+    );
+    mockArticleService.checkIfArticlesAreImported.mockResolvedValue(isImported);
+    mockArticleService.checkIfArticlesAreTranslated.mockResolvedValue(
+      isTranslated,
+    );
+    mockArticleService.getImportedArticlesByDate.mockResolvedValue(
+      importedArticlesSearchResult,
+    );
+    mockArticleService.getTranslatedArticlesByDate.mockResolvedValue(
+      translatedArticlesSearchResult,
+    );
+  };
+
   beforeEach(async () => {
+    mockArticleService = createMock<ArticleService>({
+      checkIfArticlesAreImported: jest.fn(),
+      translateArticles: jest.fn(),
+      getImportedArticlesByDate: jest.fn(),
+      getTranslatedArticlesByDate: jest.fn(),
+      importArticles: jest.fn(),
+    });
+
+    mockTranslateService = createMock({
+      checkIfTranslationLanguageIsSupported: jest.fn(),
+    });
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         FeedService,
         { provide: ArticleService, useValue: mockArticleService },
+        { provide: TranslateService, useValue: mockTranslateService },
       ],
     }).compile();
 
@@ -32,27 +72,131 @@ describe("FeedService", () => {
   });
 
   it("should get feed articles if they are already imported", async () => {
-    mockArticleService.getArticleCollectionStatus.mockResolvedValue(true);
-    mockArticleService.getArticlesByDate.mockResolvedValue(paginatedArticles);
+    setResolvedValues({
+      isTranslated: true,
+      isImported: true,
+      isLanguageSupported: true,
+      importedArticlesSearchResult: paginatedArticles,
+    });
 
-    const result = await service.getFeedArticles("2021-09-01");
+    const result = await service.getFeedArticles({});
 
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockArticleService.getArticleCollectionStatus).toHaveBeenCalled();
-    expect(mockArticleService.getArticlesByDate).toHaveBeenCalled();
+    expectCallsInMethods([
+      mockTranslateService.checkIfTranslationLanguageIsSupported,
+      mockArticleService.checkIfArticlesAreImported,
+      mockArticleService.checkIfArticlesAreTranslated,
+      mockArticleService.getImportedArticlesByDate,
+    ]);
+
+    expectNoCallsInMethods([
+      mockArticleService.importArticles,
+      mockArticleService.translateArticles,
+      mockArticleService.getTranslatedArticlesByDate,
+    ]);
   });
 
   it("should import articles if they are not imported", async () => {
-    mockArticleService.getArticleCollectionStatus.mockResolvedValue(false);
-    mockArticleService.getArticlesByDate.mockResolvedValue(paginatedArticles);
+    setResolvedValues({
+      isTranslated: true,
+      isImported: false,
+      isLanguageSupported: true,
+      importedArticlesSearchResult: paginatedArticles,
+    });
 
-    const result = await service.getFeedArticles("2021-09-01");
+    const result = await service.getFeedArticles({});
 
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockArticleService.getArticleCollectionStatus).toHaveBeenCalled();
-    expect(mockArticleService.importArticles).toHaveBeenCalled();
-    expect(mockArticleService.getArticlesByDate).toHaveBeenCalled();
+    expectCallsInMethods([
+      mockTranslateService.checkIfTranslationLanguageIsSupported,
+      mockArticleService.checkIfArticlesAreImported,
+      mockArticleService.checkIfArticlesAreTranslated,
+      mockArticleService.importArticles,
+      mockArticleService.getImportedArticlesByDate,
+    ]);
+
+    expectNoCallsInMethods([
+      mockArticleService.translateArticles,
+      mockArticleService.getTranslatedArticlesByDate,
+    ]);
+  });
+
+  it("should translate articles if they are not translated", async () => {
+    setResolvedValues({
+      isTranslated: false,
+      isImported: true,
+      isLanguageSupported: true,
+      translatedArticlesSearchResult: paginatedArticles,
+    });
+
+    const result = await service.getFeedArticles({ languageCode: "es" });
+
+    expect(result).toEqual(paginatedArticles);
+
+    expectCallsInMethods([
+      mockTranslateService.checkIfTranslationLanguageIsSupported,
+      mockArticleService.checkIfArticlesAreImported,
+      mockArticleService.checkIfArticlesAreTranslated,
+      mockArticleService.translateArticles,
+      mockArticleService.getTranslatedArticlesByDate,
+    ]);
+
+    expectNoCallsInMethods([
+      mockArticleService.importArticles,
+      mockArticleService.getImportedArticlesByDate,
+    ]);
+  });
+
+  it("should import and translate articles if they are neither translated nor imported ", async () => {
+    setResolvedValues({
+      isTranslated: false,
+      isImported: false,
+      isLanguageSupported: true,
+      translatedArticlesSearchResult: paginatedArticles,
+    });
+
+    const result = await service.getFeedArticles({ languageCode: "es" });
+
+    expect(result).toEqual(paginatedArticles);
+
+    expectCallsInMethods([
+      mockTranslateService.checkIfTranslationLanguageIsSupported,
+      mockArticleService.checkIfArticlesAreImported,
+      mockArticleService.checkIfArticlesAreTranslated,
+      mockArticleService.importArticles,
+      mockArticleService.translateArticles,
+      mockArticleService.getTranslatedArticlesByDate,
+    ]);
+
+    expectNoCallsInMethods([mockArticleService.getImportedArticlesByDate]);
+  });
+
+  it("should throw an error if the language is not supported", async () => {
+    setResolvedValues({
+      isTranslated: false,
+      isImported: false,
+      isLanguageSupported: false,
+    });
+
+    await expect(
+      service.getFeedArticles({ languageCode: "es" }),
+    ).rejects.toThrow("The requested language is not supported");
+
+    expectCallsInMethods([
+      mockTranslateService.checkIfTranslationLanguageIsSupported,
+    ]);
+  });
+
+  it("should get supported feed languages", async () => {
+    const languages = Array.from({ length: 5 }, () => createLanguageMock());
+    mockTranslateService.getSupportedLanguages.mockResolvedValue(languages);
+
+    const result = await service.getSupportedFeedLanguages();
+
+    expect(result).toEqual(languages);
+
+    expectCallsInMethods([mockTranslateService.getSupportedLanguages]);
   });
 });

--- a/backend/src/modules/feed/feed.service.spec.ts
+++ b/backend/src/modules/feed/feed.service.spec.ts
@@ -8,7 +8,7 @@ import { FeedService } from "./feed.service";
 describe("FeedService", () => {
   let service: FeedService;
   const mockArticleService = createMock<ArticleService>({
-    areDateArticlesImported: jest.fn(),
+    getArticleCollectionStatus: jest.fn(),
     getArticlesByDate: jest.fn(),
     importArticles: jest.fn(),
   });
@@ -32,26 +32,26 @@ describe("FeedService", () => {
   });
 
   it("should get feed articles if they are already imported", async () => {
-    mockArticleService.areDateArticlesImported.mockResolvedValue(true);
+    mockArticleService.getArticleCollectionStatus.mockResolvedValue(true);
     mockArticleService.getArticlesByDate.mockResolvedValue(paginatedArticles);
 
     const result = await service.getFeedArticles("2021-09-01");
 
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockArticleService.areDateArticlesImported).toHaveBeenCalled();
+    expect(mockArticleService.getArticleCollectionStatus).toHaveBeenCalled();
     expect(mockArticleService.getArticlesByDate).toHaveBeenCalled();
   });
 
   it("should import articles if they are not imported", async () => {
-    mockArticleService.areDateArticlesImported.mockResolvedValue(false);
+    mockArticleService.getArticleCollectionStatus.mockResolvedValue(false);
     mockArticleService.getArticlesByDate.mockResolvedValue(paginatedArticles);
 
     const result = await service.getFeedArticles("2021-09-01");
 
     expect(result).toEqual(paginatedArticles);
 
-    expect(mockArticleService.areDateArticlesImported).toHaveBeenCalled();
+    expect(mockArticleService.getArticleCollectionStatus).toHaveBeenCalled();
     expect(mockArticleService.importArticles).toHaveBeenCalled();
     expect(mockArticleService.getArticlesByDate).toHaveBeenCalled();
   });

--- a/backend/src/modules/feed/feed.service.ts
+++ b/backend/src/modules/feed/feed.service.ts
@@ -46,7 +46,7 @@ export class FeedService {
       await this.articleService.translateArticles(options);
     }
 
-    if (languageCode !== "en") {
+    if (options?.languageCode !== "en") {
       return await this.articleService.getTranslatedArticlesByDate(options);
     }
 

--- a/backend/src/modules/feed/feed.service.ts
+++ b/backend/src/modules/feed/feed.service.ts
@@ -1,17 +1,51 @@
 import { Injectable } from "@nestjs/common";
-import { Pagination } from "../../common/@types/types/pagination.types";
+import { startOfToday } from "date-fns";
+import { getIsoDate } from "../../common/helpers/iso-date.utils";
 import { ArticleService } from "../article/article.service";
+import { ArticleCollectionStatus } from "../article/enum/article-collection-status.enum";
+import { GetFeedArticleOptions } from "./types/get-feed-articles-options.types";
 
 @Injectable()
 export class FeedService {
   constructor(private readonly articleService: ArticleService) {}
 
-  async getFeedArticles(date: string, options?: Partial<Pagination>) {
-    if (await this.articleService.areDateArticlesImported(date)) {
-      return await this.articleService.getArticlesByDate(date, options);
+  async getFeedArticles({
+    date,
+    page,
+    pageSize,
+    languageCode,
+  }: GetFeedArticleOptions) {
+    const options = {
+      date: date ?? getIsoDate(startOfToday()),
+      page: page ?? 1,
+      pageSize: pageSize ?? 5,
+      languageCode: languageCode ?? "en",
+    };
+
+    const articleCollectionStatus =
+      await this.articleService.getArticleCollectionStatus(options);
+
+    if (articleCollectionStatus === ArticleCollectionStatus.HasAllArticles) {
+      return await this.articleService.getArticlesByDate(options);
     }
 
-    await this.articleService.importArticles(date);
-    return await this.articleService.getArticlesByDate(date, options);
+    if (
+      [
+        ArticleCollectionStatus.ImportingRequired,
+        ArticleCollectionStatus.ImportingAndTranslationRequired,
+      ].includes(articleCollectionStatus)
+    ) {
+      await this.articleService.importArticles(options);
+    }
+
+    if (
+      [
+        ArticleCollectionStatus.TranslationRequired,
+        ArticleCollectionStatus.ImportingAndTranslationRequired,
+      ].includes(articleCollectionStatus)
+    ) {
+      // this.articleService.translateArticles(options);
+    }
+    return await this.articleService.getArticlesByDate(options);
   }
 }

--- a/backend/src/modules/feed/feed.service.ts
+++ b/backend/src/modules/feed/feed.service.ts
@@ -52,4 +52,8 @@ export class FeedService {
 
     return await this.articleService.getImportedArticlesByDate(options);
   }
+
+  async getSupportedFeedLanguages() {
+    return await this.translateService.getSupportedLanguages();
+  }
 }

--- a/backend/src/modules/feed/feed.service.ts
+++ b/backend/src/modules/feed/feed.service.ts
@@ -1,12 +1,16 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { startOfToday } from "date-fns";
 import { getIsoDate } from "../../common/helpers/iso-date.utils";
 import { ArticleService } from "../article/article.service";
+import { TranslateService } from "../translate/translate.service";
 import { GetFeedArticleOptions } from "./types/get-feed-articles-options.types";
 
 @Injectable()
 export class FeedService {
-  constructor(private readonly articleService: ArticleService) {}
+  constructor(
+    private readonly articleService: ArticleService,
+    private readonly translateService: TranslateService,
+  ) {}
 
   async getFeedArticles({
     date,
@@ -20,6 +24,14 @@ export class FeedService {
       pageSize: pageSize ?? 5,
       languageCode: languageCode ?? "en",
     };
+
+    const isLanguageSupported =
+      await this.translateService.checkIfTranslationLanguageIsSupported(
+        options?.languageCode,
+      );
+    if (!isLanguageSupported) {
+      throw new BadRequestException("The requested language is not supported");
+    }
 
     const areArticlesImported =
       await this.articleService.checkIfArticlesAreImported(options);

--- a/backend/src/modules/feed/types/get-feed-articles-options.types.ts
+++ b/backend/src/modules/feed/types/get-feed-articles-options.types.ts
@@ -1,0 +1,6 @@
+import { Pagination } from "../../../common/@types/types/pagination.types";
+
+export type GetFeedArticleOptions = Partial<Pagination> & {
+  date?: string;
+  languageCode?: string;
+};

--- a/backend/src/modules/translate/translate.controller.ts
+++ b/backend/src/modules/translate/translate.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from "@nestjs/common";
+
+@Controller("translate")
+export class TranslateController {}

--- a/backend/src/modules/translate/translate.controller.ts
+++ b/backend/src/modules/translate/translate.controller.ts
@@ -1,4 +1,0 @@
-import { Controller } from "@nestjs/common";
-
-@Controller("translate")
-export class TranslateController {}

--- a/backend/src/modules/translate/translate.module.ts
+++ b/backend/src/modules/translate/translate.module.ts
@@ -1,0 +1,14 @@
+import { MikroOrmModule } from "@mikro-orm/nestjs";
+import { HttpModule } from "@nestjs/axios";
+import { Module } from "@nestjs/common";
+import { Language } from "../../database/entities/language.entity";
+import { TranslateController } from "./translate.controller";
+import { TranslateService } from "./translate.service";
+
+@Module({
+  imports: [MikroOrmModule.forFeature([Language]), HttpModule],
+  providers: [TranslateService],
+  controllers: [TranslateController],
+  exports: [TranslateService],
+})
+export class TranslateModule {}

--- a/backend/src/modules/translate/translate.module.ts
+++ b/backend/src/modules/translate/translate.module.ts
@@ -2,13 +2,11 @@ import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { HttpModule } from "@nestjs/axios";
 import { Module } from "@nestjs/common";
 import { Language } from "../../database/entities/language.entity";
-import { TranslateController } from "./translate.controller";
 import { TranslateService } from "./translate.service";
 
 @Module({
   imports: [MikroOrmModule.forFeature([Language]), HttpModule],
   providers: [TranslateService],
-  controllers: [TranslateController],
   exports: [TranslateService],
 })
 export class TranslateModule {}

--- a/backend/src/modules/translate/translate.service.spec.ts
+++ b/backend/src/modules/translate/translate.service.spec.ts
@@ -1,0 +1,182 @@
+import { createMock } from "@golevelup/ts-jest";
+import { getRepositoryToken } from "@mikro-orm/nestjs";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { HttpService } from "@nestjs/axios";
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import { BaseRepository } from "../../common/database/base.repository";
+import { Language } from "../../database/entities/language.entity";
+import { createArticleMock } from "../../mocks/article.mocks";
+import { createAxiosResponseMock } from "../../mocks/axios.mocks";
+import { createLanguageMock } from "../../mocks/language.mocks";
+import {
+  createGetAvailableLanguagesResponseMock,
+  createGetTranslatedTextResponseMock,
+} from "../../mocks/libre-translate-api.mocks";
+import { TranslateService } from "./translate.service";
+import { GetTranslatedTextRequest } from "./types/libre-translate-api-response.types";
+
+jest.mock("rxjs", () => ({
+  firstValueFrom: jest.fn().mockImplementation((value) => {
+    return value;
+  }),
+}));
+
+describe("TranslateService", () => {
+  let service: TranslateService;
+  let mockHttpService;
+  let mockLanguageRepository;
+  let mockEntityManager;
+  let mockConfigService;
+
+  const mockUrl = "https://libre-translate.com";
+  const mockGetAvailableLanguagesResponse =
+    createGetAvailableLanguagesResponseMock();
+  const mockGetTranslatedTextResponse = createGetTranslatedTextResponseMock();
+  beforeEach(async () => {
+    mockHttpService = createMock<HttpService>({
+      get: jest.fn(),
+    });
+    mockLanguageRepository = createMock<BaseRepository<Language>>({
+      findOneOrFail: jest.fn(),
+    });
+    mockEntityManager = createMock<EntityManager>({
+      fork: jest.fn(),
+    });
+    mockConfigService = createMock<ConfigService>({
+      get: jest.fn().mockReturnValue(mockUrl),
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TranslateService,
+        { provide: HttpService, useValue: mockHttpService },
+        {
+          provide: getRepositoryToken(Language),
+          useValue: mockLanguageRepository,
+        },
+        { provide: EntityManager, useValue: mockEntityManager },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<TranslateService>(TranslateService);
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("should fetch available translation languages", async () => {
+    const response = createAxiosResponseMock(mockGetAvailableLanguagesResponse);
+
+    mockHttpService.get.mockResolvedValue(response);
+
+    const result = await service.fetchAvailableTranslationLanguages();
+
+    expect(result).toEqual(mockGetAvailableLanguagesResponse);
+    expect(mockHttpService.get).toHaveBeenCalledWith(`${mockUrl}/languages`);
+  });
+
+  it("should throw error when failed to fetch available translation languages", async () => {
+    const response = createAxiosResponseMock(mockGetAvailableLanguagesResponse);
+
+    response.status = 400;
+    mockHttpService.get.mockResolvedValue(response);
+
+    expect(service.fetchAvailableTranslationLanguages()).rejects.toThrow(
+      "Failed to fetch available languages from LibreTranslate API",
+    );
+  });
+
+  it("should import translation languages", async () => {
+    const response = createAxiosResponseMock([
+      { code: "en", name: "English", targets: ["fr", "cd", "dc"] },
+      { code: "fr", name: "French", targets: ["ab", "cd", "dc"] },
+      mockGetAvailableLanguagesResponse,
+    ]);
+
+    mockHttpService.get.mockResolvedValue(response);
+    mockEntityManager.fork.mockReturnValue(mockEntityManager);
+    mockEntityManager.getRepository.mockReturnValue(mockLanguageRepository);
+
+    await service.importTranslationLanguages();
+
+    expect(mockEntityManager.fork).toHaveBeenCalled();
+    expect(mockLanguageRepository.create).toHaveBeenCalled();
+    expect(mockEntityManager.flush).toHaveBeenCalled();
+  });
+
+  it("should translate text", async () => {
+    const request: GetTranslatedTextRequest = {
+      q: ["Hello, world!"],
+      source: "en",
+      target: "fr",
+      format: "text",
+    };
+
+    const response = createAxiosResponseMock(mockGetTranslatedTextResponse);
+
+    mockHttpService.post.mockResolvedValue(response);
+
+    const result = await service.translate(request);
+
+    expect(result).toEqual(mockGetTranslatedTextResponse.translatedText);
+    expect(mockHttpService.post).toHaveBeenCalledWith(`${mockUrl}/translate`, {
+      ...request,
+    });
+  });
+
+  it("should throw error when failed to fetch translated text", async () => {
+    const request: GetTranslatedTextRequest = {
+      q: ["Hello, world!"],
+      source: "en",
+      target: "fr",
+      format: "text",
+    };
+
+    const response = createAxiosResponseMock(mockGetTranslatedTextResponse);
+
+    response.status = 400;
+    mockHttpService.post.mockResolvedValue(response);
+
+    expect(service.translate(request)).rejects.toThrow(
+      "Failed to fetch available languages from LibreTranslate API",
+    );
+  });
+
+  it("should translate articles", async () => {
+    const mockArticles = Array.from({ length: 5 }, () => createArticleMock());
+    const mockedTranslatedArticles = mockArticles.map((article) => ({
+      articleType: article.articleType,
+      articleUrl: article.articleUrl,
+      wikipediaPageId: article.wikipediaPageId,
+      thumbnail: article.thumbnail,
+      title: article.title,
+      extract: article.extract,
+      extractHtml: article.extractHtml,
+      context: article.context,
+    }));
+
+    mockHttpService.post.mockImplementation((_, params) => {
+      return createAxiosResponseMock({ translatedText: params.q });
+    });
+
+    const result = await service.translateArticles({
+      articles: mockArticles,
+      targetLanguageCode: "fr",
+    });
+
+    expect(result).toEqual(mockedTranslatedArticles);
+    expect(mockHttpService.post).toHaveBeenCalled();
+  });
+
+  it("should get the supported languages", async () => {
+    const languages = Array.from({ length: 5 }, () => createLanguageMock());
+    mockLanguageRepository.findAll.mockResolvedValue(languages);
+
+    const result = await service.getSupportedLanguages();
+
+    expect(result).toEqual(languages);
+  });
+});

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -1,0 +1,88 @@
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { EntityManager } from "@mikro-orm/postgresql";
+import { HttpService } from "@nestjs/axios";
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { AxiosResponse } from "axios";
+import { firstValueFrom } from "rxjs";
+import { BaseRepository } from "../../common/database/base.repository";
+import { Language } from "../../database/entities/language.entity";
+import { GetAvailableLanguagesResponse } from "./types/libre-translate-api-response.types";
+
+@Injectable()
+export class TranslateService {
+  constructor(
+    private readonly em: EntityManager,
+    @InjectRepository(Language)
+    private readonly languageRepository: BaseRepository<Language>,
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  async onModuleInit() {
+    const languageCount = await this.languageRepository.count();
+
+    if (languageCount > 0) return;
+
+    await this.importTranslationLanguages();
+  }
+
+  async fetchAvailableTranslationLanguages(): Promise<GetAvailableLanguagesResponse> {
+    const translateApiUrl = this.configService.get("LIBRE_TRANSLATE_API_URL");
+
+    let response: AxiosResponse<GetAvailableLanguagesResponse>;
+
+    try {
+      response = await firstValueFrom(
+        this.httpService.get(`${translateApiUrl}/languages`),
+      );
+    } catch (e) {
+      throw new Error(
+        `Failed to fetch available languages from LibreTranslate API: ${e.message}`,
+      );
+    }
+
+    if (response.status !== 200) {
+      throw new Error(
+        "Failed to fetch available languages from LibreTranslate API",
+      );
+    }
+
+    return response.data;
+  }
+
+  async importTranslationLanguages() {
+    const forkedEm = this.em.fork();
+    const forkedLanguageRepository = forkedEm.getRepository(Language);
+
+    const availableTranslations =
+      await this.fetchAvailableTranslationLanguages();
+
+    const languages: Partial<Language>[] = availableTranslations.map(
+      (language) => {
+        return {
+          code: language.code,
+          name: language.name,
+        };
+      },
+    );
+
+    const availableEnglishTranslationsTargets = availableTranslations.find(
+      (translation) => {
+        return translation.code === "en";
+      },
+    ).targets;
+
+    const availableEnglishTranslationLanguages = languages.filter(
+      (language) => {
+        return availableEnglishTranslationsTargets.includes(language.code);
+      },
+    );
+
+    availableEnglishTranslationLanguages.forEach((language) => {
+      forkedLanguageRepository.create(language);
+    });
+
+    await forkedEm.flush();
+  }
+}

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -5,9 +5,16 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { AxiosResponse } from "axios";
 import { firstValueFrom } from "rxjs";
+import { ArticleType } from "../../common/@types/enum/article-type.enum";
 import { BaseRepository } from "../../common/database/base.repository";
+import { Article } from "../../database/entities/article.entity";
 import { Language } from "../../database/entities/language.entity";
-import { GetAvailableLanguagesResponse } from "./types/libre-translate-api-response.types";
+import {
+  GetAvailableLanguagesResponse,
+  GetTranslatedTextRequest,
+  GetTranslatedTextResponse,
+} from "./types/libre-translate-api-response.types";
+import { TranslateArticleOptions } from "./types/translation.types";
 
 @Injectable()
 export class TranslateService {
@@ -84,5 +91,111 @@ export class TranslateService {
     });
 
     await forkedEm.flush();
+  }
+
+  async translate(request: GetTranslatedTextRequest): Promise<string[]> {
+    const translateApiUrl = this.configService.get("LIBRE_TRANSLATE_API_URL");
+
+    let response: AxiosResponse<GetTranslatedTextResponse>;
+
+    try {
+      response = await firstValueFrom(
+        this.httpService.post(`${translateApiUrl}/translate`, {
+          ...request,
+        }),
+      );
+    } catch (e) {
+      throw new Error(
+        `Failed to fetch available languages from LibreTranslate API: ${e.message}`,
+      );
+    }
+
+    if (response.status !== 200) {
+      throw new Error(
+        "Failed to fetch available languages from LibreTranslate API",
+      );
+    }
+
+    return response.data.translatedText;
+  }
+
+  async translateArticles({
+    articles,
+    targetLanguageCode,
+  }: TranslateArticleOptions): Promise<Partial<Article>[]> {
+    const textsToTranslate = articles.reduce(
+      (accumulatedTextsToTranslate, article) => {
+        if (article.articleType === ArticleType.News) {
+          return [
+            ...accumulatedTextsToTranslate,
+            article.title,
+            article.extract,
+            "",
+          ];
+        }
+
+        return [
+          ...accumulatedTextsToTranslate,
+          article.title,
+          article.extract,
+          article.context ?? "",
+        ];
+      },
+      [],
+    );
+
+    const htmlToTranslate = articles.reduce(
+      (accumulatedHtmlToTranslate, article) => {
+        if (article.articleType === ArticleType.News) {
+          return [...accumulatedHtmlToTranslate, article.extractHtml, ""];
+        }
+
+        return [
+          ...accumulatedHtmlToTranslate,
+          article.extractHtml,
+          article.context ?? "",
+        ];
+      },
+      [],
+    );
+
+    const translatedTextsPromise = this.translate({
+      q: textsToTranslate,
+      target: targetLanguageCode,
+      source: "en",
+      format: "text",
+    });
+
+    const translatedHtmlPromise = this.translate({
+      q: htmlToTranslate,
+      target: targetLanguageCode,
+      source: "en",
+      format: "html",
+    });
+
+    const [translatedTexts, translatedHtml] = await Promise.all([
+      translatedTextsPromise,
+      translatedHtmlPromise,
+    ]);
+
+    const translatedArticles: Partial<Article>[] = [];
+
+    articles.forEach((article) => {
+      const [title, extract, context] = translatedTexts.splice(0, 3);
+      const [extractHtml, contextHtml] = translatedHtml.splice(0, 2);
+
+      translatedArticles.push({
+        articleType: article.articleType,
+        articleUrl: article.articleUrl,
+        wikipediaPageId: article.wikipediaPageId,
+        thumbnail: article.thumbnail,
+        title,
+        extract,
+        extractHtml,
+        context: context ?? contextHtml ?? null,
+      });
+    });
+
+    return translatedArticles;
   }
 }

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -1,7 +1,7 @@
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { EntityManager } from "@mikro-orm/postgresql";
 import { HttpService } from "@nestjs/axios";
-import { Injectable } from "@nestjs/common";
+import { Injectable, InternalServerErrorException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { AxiosResponse } from "axios";
 import { firstValueFrom } from "rxjs";
@@ -44,13 +44,13 @@ export class TranslateService {
         this.httpService.get(`${translateApiUrl}/languages`),
       );
     } catch (e) {
-      throw new Error(
+      throw new InternalServerErrorException(
         `Failed to fetch available languages from LibreTranslate API: ${e.message}`,
       );
     }
 
     if (response.status !== 200) {
-      throw new Error(
+      throw new InternalServerErrorException(
         "Failed to fetch available languages from LibreTranslate API",
       );
     }
@@ -105,13 +105,13 @@ export class TranslateService {
         }),
       );
     } catch (e) {
-      throw new Error(
+      throw new InternalServerErrorException(
         `Failed to fetch available languages from LibreTranslate API: ${e.message}`,
       );
     }
 
     if (response.status !== 200) {
-      throw new Error(
+      throw new InternalServerErrorException(
         "Failed to fetch available languages from LibreTranslate API",
       );
     }

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -119,6 +119,14 @@ export class TranslateService {
     return response.data.translatedText;
   }
 
+  async checkIfTranslationLanguageIsSupported(languageCode: string) {
+    const languageCount = await this.languageRepository.count({
+      code: languageCode,
+    });
+
+    return languageCount > 0;
+  }
+
   async translateArticles({
     articles,
     targetLanguageCode,

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -119,6 +119,10 @@ export class TranslateService {
     return response.data.translatedText;
   }
 
+  async getSupportedLanguages(): Promise<Language[]> {
+    return this.languageRepository.findAll();
+  }
+
   async checkIfTranslationLanguageIsSupported(languageCode: string) {
     const languageCount = await this.languageRepository.count({
       code: languageCode,

--- a/backend/src/modules/translate/translate.service.ts
+++ b/backend/src/modules/translate/translate.service.ts
@@ -158,7 +158,7 @@ export class TranslateService {
 
     const htmlToTranslate = articles.reduce(
       (accumulatedHtmlToTranslate, article) => {
-        if (article.articleType === ArticleType.News) {
+        if (article.articleType === ArticleType.OnThisDay) {
           return [...accumulatedHtmlToTranslate, article.extractHtml, ""];
         }
 
@@ -196,6 +196,10 @@ export class TranslateService {
       const [title, extract, context] = translatedTexts.splice(0, 3);
       const [extractHtml, contextHtml] = translatedHtml.splice(0, 2);
 
+      let articleContext = context || contextHtml;
+
+      if (articleContext.length === 0) articleContext = null;
+
       translatedArticles.push({
         articleType: article.articleType,
         articleUrl: article.articleUrl,
@@ -204,7 +208,7 @@ export class TranslateService {
         title,
         extract,
         extractHtml,
-        context: context ?? contextHtml ?? null,
+        context: articleContext,
       });
     });
 

--- a/backend/src/modules/translate/types/libre-translate-api-response.types.ts
+++ b/backend/src/modules/translate/types/libre-translate-api-response.types.ts
@@ -1,14 +1,14 @@
 export type GetAvailableLanguagesResponse = AvailableTranslation[];
 
 export type GetTranslatedTextRequest = {
-  q: string;
+  q: string[];
   source: string;
   target: string;
   format: "text" | "html";
 };
 
 export type GetTranslatedTextResponse = {
-  translatedText: string;
+  translatedText: string[];
 };
 
 export type AvailableTranslation = {

--- a/backend/src/modules/translate/types/libre-translate-api-response.types.ts
+++ b/backend/src/modules/translate/types/libre-translate-api-response.types.ts
@@ -1,0 +1,18 @@
+export type GetAvailableLanguagesResponse = AvailableTranslation[];
+
+export type GetTranslatedTextRequest = {
+  q: string;
+  source: string;
+  target: string;
+  format: "text" | "html";
+};
+
+export type GetTranslatedTextResponse = {
+  translatedText: string;
+};
+
+export type AvailableTranslation = {
+  code: string;
+  name: string;
+  targets: string[];
+};

--- a/backend/src/modules/translate/types/translation.types.ts
+++ b/backend/src/modules/translate/types/translation.types.ts
@@ -1,0 +1,6 @@
+import { Article } from "../../../database/entities/article.entity";
+
+export type TranslateArticleOptions = {
+  articles: Article[];
+  targetLanguageCode: string;
+};

--- a/backend/src/modules/wikipedia/wikipedia.service.spec.ts
+++ b/backend/src/modules/wikipedia/wikipedia.service.spec.ts
@@ -65,7 +65,8 @@ describe("WikipediaService", () => {
     const amountOfArticles =
       1 +
       mockWikipediaApiResponse.mostread.articles.length +
-      mockWikipediaApiResponse.onthisday.length;
+      mockWikipediaApiResponse.onthisday.length +
+      mockWikipediaApiResponse.news.length;
 
     mockHttpService.get.mockResolvedValue(mockAxiosResponse as never);
 

--- a/backend/src/modules/wikipedia/wikipedia.service.ts
+++ b/backend/src/modules/wikipedia/wikipedia.service.ts
@@ -1,5 +1,5 @@
 import { HttpService } from "@nestjs/axios";
-import { Injectable } from "@nestjs/common";
+import { Injectable, InternalServerErrorException } from "@nestjs/common";
 import { AxiosResponse } from "axios";
 import { firstValueFrom } from "rxjs";
 import { ArticleType } from "../../common/@types/enum/article-type.enum";
@@ -13,13 +13,21 @@ export class WikipediaService {
 
   async fetchFeaturedContents(date: string): Promise<WikipediaArticle[]> {
     const uriDate = date.split("-").join("/");
-
-    const response: AxiosResponse<WikipediaApiResponse> = await firstValueFrom(
-      this.httpService.get(`${WIKIPEDIA_API_URL}${uriDate}`),
-    );
+    let response: AxiosResponse<WikipediaApiResponse>;
+    try {
+      response = await firstValueFrom(
+        this.httpService.get(`${WIKIPEDIA_API_URL}${uriDate}`),
+      );
+    } catch (e) {
+      throw new InternalServerErrorException(
+        `Failed to fetch data from Wikipedia API: ${e.message}`,
+      );
+    }
 
     if (response.status !== 200) {
-      throw new Error("Failed to fetch data from Wikipedia API");
+      throw new InternalServerErrorException(
+        "Failed to fetch data from Wikipedia API",
+      );
     }
 
     const articles: WikipediaArticle[] = [];

--- a/backend/src/modules/wikipedia/wikipedia.service.ts
+++ b/backend/src/modules/wikipedia/wikipedia.service.ts
@@ -45,6 +45,16 @@ export class WikipediaService {
       });
     }
 
+    if (response.data.news) {
+      response.data.news.forEach((news) => {
+        articles.push({
+          ...news.links[0],
+          articleType: ArticleType.News,
+          story: news.story,
+        });
+      });
+    }
+
     return articles;
   }
 }


### PR DESCRIPTION
## Description

Implemented `/feed/translate/{languageCode}` endpoints to provide articles translated by LibreTranslate API.

## Changes

### Back-End

- Added article collection and language entities
- Added extract_html and context columns to article entity, removed featured_date column since the article collection entity handles that value.
- Added TranslateModule with the following functionalities:
  - To populate the languages table with the supported translation language LibreTranslate API has, it will make an attempt each time the module initializes.
  - To retrieve supported translation languages.
  - To translate articles text and html.
  - To identify if a given language code is a supported translation language.
- Extended Feed Module with the following functions:
  - It now exposes the `/feed/translate/{languageCode}` and `/feed/{date}/translate/{languageCode}` endpoints, which will provide translated featured articles to the given language.
  - It now exposes the `/feed/languages` endpoint which provides a list of all the supported languages.
- Extended Article Module with the following functionalities:
  - To determine if the queried articles are translated already.
  - To search for translated articles by date.
  - To translate and save newly translated articles.
- Added unit tests for the new functionalities.