### PR TITLE
Add Visual Indicators for Already Read Articles and Loading and Error States

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.3.5",
     "antd": "^5.15.4",
     "axios": "^1.6.8",
     "classnames": "^2.5.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@ant-design/icons':
+    specifier: ^5.3.5
+    version: 5.3.5(react-dom@18.2.0)(react@18.2.0)
   antd:
     specifier: ^5.15.4
     version: 5.15.4(react-dom@18.2.0)(react@18.2.0)

--- a/frontend/src/components/article-card/ArticleCard.css
+++ b/frontend/src/components/article-card/ArticleCard.css
@@ -3,6 +3,10 @@
   border-color: var(--component-border)
 }
 
+.article-card .ant-card-head {
+  border-color: var(--component-border)
+}
+
 .article-card:hover {
   background-color: var(--component-background-hover);
   box-shadow: 0 0 8cap 0 rgba(0, 0, 0, 0.3);
@@ -15,6 +19,10 @@
 
 .article-card-read {
   background-color: var(--component-read-background);
+  border-color: var(--component-read-border);
+}
+
+.article-card-read .ant-card-head {
   border-color: var(--component-read-border);
 }
 

--- a/frontend/src/components/article-card/ArticleCard.css
+++ b/frontend/src/components/article-card/ArticleCard.css
@@ -9,6 +9,23 @@
   cursor: pointer;
 }
 
+.article-card:active {
+  background-color: var(--component-background-active);
+}
+
+.article-card-read {
+  background-color: var(--component-read-background);
+  border-color: var(--component-read-border);
+}
+
+.article-card.article-card-read:hover {
+  background-color: var(--component-read-background-hover);
+}
+
+.article-card.article-card-read:active {
+  background-color: var(--component-read-background-active);
+}
+
 .article-card .ant-card-body {
   display: flex; 
   flex-direction: column;

--- a/frontend/src/components/article-card/ArticleCard.tsx
+++ b/frontend/src/components/article-card/ArticleCard.tsx
@@ -1,7 +1,7 @@
 import { Card } from "antd";
 import classNames from "classnames";
 import { useSanitizeHtml } from "../../hooks/useSanitizeHtml";
-import { Article } from "../../types/article";
+import { Article, articleTypeToTitle } from "../../types/article";
 import WikipediaIcon from "./../../assets/wikipedia-icon.jpg";
 
 import { ImageWithFallback } from "../image-with-fallback/ImageWithFallback";
@@ -36,6 +36,7 @@ export const ArticleCard = ({
       data-testid="article-card"
       className={cardClassName}
       onClick={handleClick}
+      title={articleTypeToTitle[article.articleType]}
     >
       <ImageWithFallback
         src={article?.thumbnail?.url}

--- a/frontend/src/components/article-card/ArticleCard.tsx
+++ b/frontend/src/components/article-card/ArticleCard.tsx
@@ -10,18 +10,21 @@ import "./ArticleCard.css";
 export type ArticleCardProps = {
   article: Article;
   alreadyRead?: boolean;
+  onClick?: (article: Article) => void;
   className?: string;
 };
 
 export const ArticleCard = ({
   article,
   alreadyRead,
+  onClick,
   className,
 }: ArticleCardProps) => {
   const { sanitize } = useSanitizeHtml();
 
   const handleClick = () => {
     window.open(article.articleUrl, "_blank");
+    if (onClick) onClick(article);
   };
 
   const cardClassName = classNames("article-card", className, {

--- a/frontend/src/components/article-card/ArticleCard.tsx
+++ b/frontend/src/components/article-card/ArticleCard.tsx
@@ -44,7 +44,7 @@ export const ArticleCard = ({
         fallback={WikipediaIcon}
         className="article-card-image"
       />
-      <div className="article-card-separator"></div>
+      <div className="article-card-separator" />
       <div className="article-card-title">{article.title}</div>
       {article?.context && (
         <div

--- a/frontend/src/components/article-card/__tests__/ArticleCard.test.tsx
+++ b/frontend/src/components/article-card/__tests__/ArticleCard.test.tsx
@@ -59,4 +59,18 @@ describe("Article Card", () => {
 
     expect(articleCard).toHaveClass("article-card-read");
   });
+
+  test("should call onClick when article card is clicked", () => {
+    const onClick = vi.fn();
+
+    const { getByTestId } = render(
+      <ArticleCard article={articleMock} onClick={onClick} />,
+    );
+
+    const articleCard = getByTestId("article-card");
+
+    fireEvent.click(articleCard);
+
+    expect(onClick).toHaveBeenCalledWith(articleMock);
+  });
 });

--- a/frontend/src/components/article-feed/ArticleFeed.css
+++ b/frontend/src/components/article-feed/ArticleFeed.css
@@ -2,12 +2,17 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  flex: 1;
 }
 
 .article-feed-articles {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 16px;
+}
+
+.article-feed-articles.state {
+  display: flex;
 }
 
 .article-feed-pagination {

--- a/frontend/src/components/article-feed/ArticleFeed.tsx
+++ b/frontend/src/components/article-feed/ArticleFeed.tsx
@@ -28,7 +28,12 @@ export const ArticleFeed = ({
     ...pagination,
   });
 
+  const [totalItems, setTotalItems] = useState<number>(1);
   const [readArticlesIds, setReadArticlesIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    if (data?.meta?.total) setTotalItems(data.meta.total);
+  }, [data?.meta?.total]);
 
   useEffect(() => {
     setReadArticlesIds(
@@ -87,7 +92,7 @@ export const ArticleFeed = ({
         pageSize={pagination.pageSize}
         defaultPageSize={5}
         pageSizeOptions={[5, 15, 30]}
-        total={data?.meta.total ?? 0}
+        total={totalItems}
         onChange={handlePageChange}
         onShowSizeChange={handlePageSizeChange}
         disabled={isLoading}

--- a/frontend/src/components/article-feed/ArticleFeed.tsx
+++ b/frontend/src/components/article-feed/ArticleFeed.tsx
@@ -5,6 +5,7 @@ import { ArticleCard } from "../article-card/ArticleCard";
 
 import { useFeed } from "../../api/useFeed";
 import { Article } from "../../types/article";
+import { StateProvider } from "../state-provider/StateProvider";
 import "./ArticleFeed.css";
 
 export type ArticleFeedProps = {
@@ -21,7 +22,7 @@ export const ArticleFeed = ({
   const [pagination, setPagination] = useState({ page: 1, pageSize: 5 });
 
   const { useGetFeedQuery } = useFeed();
-  const { data, isLoading } = useGetFeedQuery({
+  const { data, isLoading, isError } = useGetFeedQuery({
     date,
     languageCode,
     ...pagination,
@@ -63,7 +64,11 @@ export const ArticleFeed = ({
 
   return (
     <div className={containerClass}>
-      <div className="article-feed-articles">
+      <StateProvider
+        className="article-feed-articles"
+        isLoading={isLoading}
+        isError={isError}
+      >
         {data?.items.map((article) => (
           <ArticleCard
             article={article}
@@ -72,7 +77,7 @@ export const ArticleFeed = ({
             alreadyRead={readArticlesIds.includes(article.wikipediaPageId)}
           />
         ))}
-      </div>
+      </StateProvider>
       <Pagination
         data-testid="article-feed-pagination"
         className="article-feed-pagination"

--- a/frontend/src/components/article-feed/ArticleFeed.tsx
+++ b/frontend/src/components/article-feed/ArticleFeed.tsx
@@ -1,9 +1,10 @@
 import { Pagination } from "antd";
 import classNames from "classnames";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ArticleCard } from "../article-card/ArticleCard";
 
 import { useFeed } from "../../api/useFeed";
+import { Article } from "../../types/article";
 import "./ArticleFeed.css";
 
 export type ArticleFeedProps = {
@@ -26,11 +27,36 @@ export const ArticleFeed = ({
     ...pagination,
   });
 
+  const [readArticlesIds, setReadArticlesIds] = useState<number[]>([]);
+
+  useEffect(() => {
+    setReadArticlesIds(
+      JSON.parse(window.localStorage.getItem("readArticles") || "[]"),
+    );
+  }, []);
+
   const handlePageChange = (page: number) => {
     setPagination((previousPagination) => ({ ...previousPagination, page }));
   };
   const handlePageSizeChange = (page: number, pageSize: number) => {
     setPagination({ page, pageSize });
+  };
+
+  const handleArticleClick = (article: Article) => {
+    const articleWikipediaPageId = article.wikipediaPageId;
+
+    window.localStorage.setItem(
+      "readArticles",
+      JSON.stringify([...readArticlesIds, articleWikipediaPageId]),
+    );
+
+    setReadArticlesIds((previousReadArticlesIds) => {
+      if (previousReadArticlesIds?.includes(articleWikipediaPageId)) {
+        return previousReadArticlesIds;
+      }
+
+      return [...previousReadArticlesIds, articleWikipediaPageId];
+    });
   };
 
   const containerClass = classNames("article-feed", className);
@@ -39,7 +65,12 @@ export const ArticleFeed = ({
     <div className={containerClass}>
       <div className="article-feed-articles">
         {data?.items.map((article) => (
-          <ArticleCard article={article} key={article.id} />
+          <ArticleCard
+            article={article}
+            key={article.id}
+            onClick={handleArticleClick}
+            alreadyRead={readArticlesIds.includes(article.wikipediaPageId)}
+          />
         ))}
       </div>
       <Pagination

--- a/frontend/src/components/article-feed/__tests__/ArticleFeed.test.tsx
+++ b/frontend/src/components/article-feed/__tests__/ArticleFeed.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render } from "@testing-library/react";
 import { UseQueryResult } from "react-query";
+import { Mock } from "vitest";
 import { useFeed } from "../../../api/useFeed";
 import { createArticleMock } from "../../../mocks/article";
 import { Article } from "../../../types/article";
@@ -9,23 +10,42 @@ import { ArticleFeed } from "../ArticleFeed";
 vi.mock("../../../api/useFeed");
 
 vi.mock("../../article-card/ArticleCard", () => ({
-  ArticleCard: () => {
-    return <div data-testid="article-card" />;
+  ArticleCard: ({
+    article,
+    onClick,
+  }: {
+    article: Article;
+    onClick: (article: Article) => void;
+  }) => {
+    return <div data-testid="article-card" onClick={() => onClick(article)} />;
   },
 }));
 
 describe("Article Feed", async () => {
   const articleMocks = Array.from({ length: 5 }, () => createArticleMock());
 
+  const originalWindowLocalStorage = window.localStorage;
+
+  beforeEach(() => {
+    window.localStorage = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+    } as unknown as Storage;
+  });
+
+  afterEach(() => {
+    window.localStorage = originalWindowLocalStorage;
+  });
+
   const mockUseGetFeedQueryResponse = (
     response: PaginatedResponse<Article>,
+    states?: { isLoading: boolean; isError: boolean },
   ) => {
-    const mockUseGetFeedQuery = vi
-      .fn()
-      .mockReturnValue({ data: response, isLoading: false } as UseQueryResult<
-        PaginatedResponse<Article>,
-        unknown
-      >);
+    const mockUseGetFeedQuery = vi.fn().mockReturnValue({
+      data: response,
+      isLoading: false,
+      ...states,
+    } as UseQueryResult<PaginatedResponse<Article>, unknown>);
 
     vi.mocked(useFeed).mockReturnValue({
       ...((() => {}) as typeof useFeed)(),
@@ -63,7 +83,7 @@ describe("Article Feed", async () => {
     expect(getAllByTestId("article-card").length).toBe(5);
   });
 
-  test("should go to the next page on page next button click", async () => {
+  test("should go to the next page on page next button click", () => {
     const date = "2024-03-29";
 
     const mockUseGetFeedQuery = mockUseGetFeedQueryResponse({
@@ -90,7 +110,7 @@ describe("Article Feed", async () => {
     });
   });
 
-  test("should go to back to the previous page on previous page button click", async () => {
+  test("should go to back to the previous page on previous page button click", () => {
     const date = "2024-03-29";
 
     const mockUseGetFeedQuery = mockUseGetFeedQueryResponse({
@@ -112,7 +132,11 @@ describe("Article Feed", async () => {
     const prevPageButton = pagination.querySelector(".ant-pagination-prev");
     fireEvent.click(prevPageButton!);
 
-    expect(mockUseGetFeedQuery.mock.calls[2][0]).toEqual({
+    expect(
+      mockUseGetFeedQuery.mock.calls[
+        mockUseGetFeedQuery.mock.calls.length - 1
+      ][0],
+    ).toEqual({
       date,
       page: 1,
       languageCode: undefined,
@@ -120,7 +144,7 @@ describe("Article Feed", async () => {
     });
   });
 
-  test("should change page size on page size change", async () => {
+  test("should change page size on page size change", () => {
     const date = "2024-03-29";
 
     const mockUseGetFeedQuery = mockUseGetFeedQueryResponse({
@@ -146,6 +170,122 @@ describe("Article Feed", async () => {
       page: 1,
       languageCode: undefined,
       pageSize: 15,
+    });
+  });
+
+  test("should call window localStorage on article click", () => {
+    const date = "2024-03-29";
+
+    mockUseGetFeedQueryResponse({
+      items: articleMocks,
+      meta: {
+        total: 50,
+        page: 1,
+        pageSize: 5,
+        totalPages: 10,
+      },
+    });
+
+    const { getAllByTestId } = render(<ArticleFeed date={date} />);
+
+    const articleCard = getAllByTestId("article-card")[0];
+    fireEvent.click(articleCard);
+
+    expect(window.localStorage.setItem).toBeCalledWith(
+      "readArticles",
+      JSON.stringify([articleMocks[0].wikipediaPageId]),
+    );
+  });
+
+  test("should get already read articles from localStorage", () => {
+    const date = "2024-03-29";
+
+    mockUseGetFeedQueryResponse({
+      items: articleMocks,
+      meta: {
+        total: 50,
+        page: 1,
+        pageSize: 5,
+        totalPages: 10,
+      },
+    });
+
+    (window.localStorage.getItem as Mock).mockReturnValue(
+      JSON.stringify([articleMocks[0].wikipediaPageId]),
+    );
+
+    render(<ArticleFeed date={date} />);
+
+    expect(window.localStorage.getItem).toBeCalledWith("readArticles");
+  });
+
+  test("should render loading state when fetch query is loading", () => {
+    const date = "2024-03-29";
+
+    mockUseGetFeedQueryResponse(
+      {
+        items: [],
+        meta: {
+          total: 0,
+          page: 1,
+          pageSize: 5,
+          totalPages: 0,
+        },
+      },
+      { isLoading: true, isError: false },
+    );
+
+    const { getByTestId } = render(<ArticleFeed date={date} />);
+
+    const loadingStateIcon = getByTestId("loading-state-icon");
+
+    expect(loadingStateIcon).toBeInTheDocument();
+  });
+
+  test("should render error state on fetch query error", () => {
+    const date = "2024-03-29";
+
+    mockUseGetFeedQueryResponse(
+      {
+        items: [],
+        meta: {
+          total: 0,
+          page: 1,
+          pageSize: 5,
+          totalPages: 0,
+        },
+      },
+      { isLoading: false, isError: true },
+    );
+
+    const { getByTestId } = render(<ArticleFeed date={date} />);
+
+    const loadingStateIcon = getByTestId("error-state-icon");
+
+    expect(loadingStateIcon).toBeInTheDocument();
+  });
+
+  test("should pass in language code to fetch query hook", () => {
+    const date = "2024-03-29";
+    const languageCode = "fr";
+
+    const mockUseGetFeedQuery = mockUseGetFeedQueryResponse({
+      items: articleMocks,
+      meta: {
+        total: 50,
+        page: 1,
+        pageSize: 5,
+        totalPages: 10,
+      },
+    });
+
+    render(<ArticleFeed date={date} languageCode={languageCode} />);
+
+    expect(mockUseGetFeedQuery).toBeCalledWith({
+      date,
+      page: 1,
+      languageCode,
+      pageSize: 5,
     });
   });
 });

--- a/frontend/src/components/state-provider/StateProvider.tsx
+++ b/frontend/src/components/state-provider/StateProvider.tsx
@@ -25,13 +25,15 @@ export const StateProvider = ({
     return (
       <State
         className={stateClassName}
-        icon={<CloseCircleOutlined />}
+        icon={<CloseCircleOutlined data-testid="error-state-icon" />}
         message="Error"
       />
     );
 
   if (isLoading)
-    return <State className={stateClassName} icon={<LoadingOutlined />} />;
+    return (
+      <State icon={<LoadingOutlined data-testid="loading-state-icon" />} />
+    );
 
   return <div className={stateClassName}>{children}</div>;
 };

--- a/frontend/src/components/state-provider/StateProvider.tsx
+++ b/frontend/src/components/state-provider/StateProvider.tsx
@@ -1,0 +1,37 @@
+import { CloseCircleOutlined, LoadingOutlined } from "@ant-design/icons";
+import classNames from "classnames";
+import { ReactNode } from "react";
+import { State } from "./state/State";
+
+export type StateProviderProps = {
+  children: ReactNode;
+  isLoading: boolean;
+  isError: boolean;
+  className?: string;
+};
+
+export const StateProvider = ({
+  children,
+  isLoading,
+  isError,
+  className,
+}: StateProviderProps) => {
+  const stateClassName = classNames("state-provider", className, {
+    "state-provider-loading": isLoading,
+    "state-provider-error": isError,
+  });
+
+  if (isError)
+    return (
+      <State
+        className={stateClassName}
+        icon={<CloseCircleOutlined />}
+        message="Error"
+      />
+    );
+
+  if (isLoading)
+    return <State className={stateClassName} icon={<LoadingOutlined />} />;
+
+  return <div className={stateClassName}>{children}</div>;
+};

--- a/frontend/src/components/state-provider/__tests__/StateProvider.test.tsx
+++ b/frontend/src/components/state-provider/__tests__/StateProvider.test.tsx
@@ -1,0 +1,48 @@
+import { render } from "@testing-library/react";
+import { StateProvider } from "../StateProvider";
+
+describe("State Provider", () => {
+  it("should render correctly", () => {
+    render(
+      <StateProvider isLoading={false} isError={false}>
+        <div></div>
+      </StateProvider>,
+    );
+  });
+
+  it("should render children when not loading or in error state", () => {
+    const { getByText } = render(
+      <StateProvider isLoading={false} isError={false}>
+        <div>Children</div>
+      </StateProvider>,
+    );
+
+    const children = getByText("Children");
+
+    expect(children).toBeInTheDocument();
+  });
+
+  it("should render loading state", () => {
+    const { getByTestId } = render(
+      <StateProvider isLoading={true} isError={false}>
+        <div></div>
+      </StateProvider>,
+    );
+
+    const loadingStateIcon = getByTestId("loading-state-icon");
+
+    expect(loadingStateIcon).toBeInTheDocument();
+  });
+
+  it("should render error state", () => {
+    const { getByTestId } = render(
+      <StateProvider isLoading={false} isError={true}>
+        <div></div>
+      </StateProvider>,
+    );
+
+    const errorStateIcon = getByTestId("error-state-icon");
+
+    expect(errorStateIcon).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/state-provider/state/State.css
+++ b/frontend/src/components/state-provider/state/State.css
@@ -1,0 +1,20 @@
+.state {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  flex: 1;
+}
+
+.state-icon svg {
+    width: 80px;
+    height: 80px;
+    color: var(--secondary)
+}
+
+.state-message {
+    font-size: 24px;
+    font-weight: 600;
+}

--- a/frontend/src/components/state-provider/state/State.tsx
+++ b/frontend/src/components/state-provider/state/State.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from "react";
+
+import classNames from "classnames";
+import "./State.css";
+
+export type StateProps = {
+  icon: ReactNode;
+  message?: string;
+  className?: string;
+};
+
+export const State = ({ icon, message, className }: StateProps) => {
+  const stateClassName = classNames("state", className);
+
+  return (
+    <div className={stateClassName}>
+      <div className="state-icon">{icon}</div>
+      {message && <div className="state-message">{message}</div>}
+    </div>
+  );
+};

--- a/frontend/src/components/state-provider/state/__tests__/State.test.tsx
+++ b/frontend/src/components/state-provider/state/__tests__/State.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { State } from "../State";
+
+describe("State", () => {
+  const defaultProps = {
+    icon: <></>,
+    message: "",
+  };
+
+  it("should render correctly", () => {
+    render(<State {...defaultProps} />);
+  });
+
+  it("should render the icon and message", () => {
+    const { getByText } = render(
+      <State icon={<span>Icon</span>} message="message" />,
+    );
+
+    const icon = getByText("Icon");
+    const message = getByText("message");
+
+    expect(icon).toBeInTheDocument();
+    expect(message).toBeInTheDocument();
+  });
+});

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -1,3 +1,9 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 html, body, #root {
   height: 100%;
   margin: 0;

--- a/frontend/src/global.css
+++ b/frontend/src/global.css
@@ -22,7 +22,12 @@ body {
   --component-background: #f0f0f0;;
   --component-background-secondary: #9e9e9e;;
   --component-background-hover: #e0e0e0;
+  --component-background-active: #d0d0d0;
   --component-border: #bcbcbc;
+  --component-read-background: #d1cde3;
+  --component-read-background-hover: #c1b9d3;
+  --component-read-background-active: #b1a9c3;
+  --component-read-border: #adaaca;
 
   --text-primary: #212121;
   --text-secondary: #757575;

--- a/frontend/src/pages/feed/Feed.css
+++ b/frontend/src/pages/feed/Feed.css
@@ -1,8 +1,9 @@
-.feed-page-content {
+.feed-page {
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  min-height: 100%;
 }
 
 .feed-header {

--- a/frontend/src/pages/feed/Feed.tsx
+++ b/frontend/src/pages/feed/Feed.tsx
@@ -13,7 +13,7 @@ export const Feed = () => {
   });
 
   return (
-    <div className="feed-page-content">
+    <div className="feed-page">
       <div className="feed-header">Featured Article Feed</div>
       <div className="feed-section-separator" />
 

--- a/frontend/src/providers/AntdConfigProvider.tsx
+++ b/frontend/src/providers/AntdConfigProvider.tsx
@@ -1,0 +1,20 @@
+import { ConfigProvider } from "antd";
+import { ReactNode } from "react";
+
+export type AntdConfigProviderProps = {
+  children: ReactNode;
+};
+
+export const AntdConfigProvider = ({ children }: AntdConfigProviderProps) => {
+  return (
+    <ConfigProvider
+      theme={{
+        token: {
+          colorPrimary: "#8d6e63",
+        },
+      }}
+    >
+      {children}
+    </ConfigProvider>
+  );
+};

--- a/frontend/src/providers/Providers.tsx
+++ b/frontend/src/providers/Providers.tsx
@@ -1,6 +1,7 @@
 import { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter } from "react-router-dom";
+import { AntdConfigProvider } from "./AntdConfigProvider";
 
 export type ProvidersProps = {
   children: ReactNode;
@@ -11,7 +12,9 @@ const queryClient = new QueryClient();
 export const Providers = ({ children }: ProvidersProps) => {
   return (
     <BrowserRouter>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <AntdConfigProvider>{children}</AntdConfigProvider>
+      </QueryClientProvider>
     </BrowserRouter>
   );
 };

--- a/frontend/src/types/article.ts
+++ b/frontend/src/types/article.ts
@@ -14,7 +14,7 @@ export type Article = BaseEntity & {
   extractHtml: string;
   context?: string;
   articleUrl: string;
-  articleType: string;
+  articleType: ArticleType;
   wikipediaPageId: number;
   thumbnail: Thumbnail;
 };
@@ -35,4 +35,11 @@ export enum ArticleType {
 export type ArticleFeedParams = {
   date: string;
   languageCode: string;
+};
+
+export const articleTypeToTitle: { [key in ArticleType]: string } = {
+  [ArticleType.Featured]: "Featured",
+  [ArticleType.MostRead]: "Most Read",
+  [ArticleType.News]: "News",
+  [ArticleType.OnThisDay]: "On This Day...",
 };


### PR DESCRIPTION
## Description

Added visual indicator for already read articles, as well as loading states and error states for article feed. Added article type to article cards.

![image](https://github.com/ArturoAHR/wiki-feats/assets/54607567/ed13196d-9949-41a2-9682-986ac8bbef07)

## Changes

### Front-End

- Added visual indicators for already read articles, the list of read articles is locally stored so the state persists between sessions.
- Added article type to article card component.
- Added loading and error states for article feed.
- Fixed page indicator turning to 0 while articles were loading.
- Fixed Ant Design theme colors.
